### PR TITLE
docs: uncomment README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # adk-docker-uv
 
-<!-- ![Build](https://github.com/onix-net/digital-co-worker/actions/workflows/docker-build-push.yml/badge.svg)
-![CI](https://github.com/onix-net/digital-co-worker/actions/workflows/code-quality.yml/badge.svg) -->
+![Build](https://github.com/doughayden/adk-docker-uv/actions/workflows/docker-build-push.yml/badge.svg)
+![CI](https://github.com/doughayden/adk-docker-uv/actions/workflows/code-quality.yml/badge.svg)
 
 ADK on Docker, optimized with uv
 


### PR DESCRIPTION
## What
Uncomment and activate the Build and CI status badges in the README.

## Why
The badges were commented out during initial development but should now be visible to show project status.

## How
- Uncommented the Build and CI badge markdown
- Updated badge URLs to point to the correct repository (doughayden/adk-docker-uv)

## Tests
- [x] Verified badge URLs point to correct repository
- [x] Confirmed badge markdown syntax is correct