### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-11-17
+
 ### Added
 - Template initialization script (`init_template.py`) with dry-run mode.
 - Init script audit logs (`init_template_results.md`, `init_template_dry_run.md`) for change tracking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adk-docker-uv"
-version = "0.1.0"
+version = "0.2.0"
 description = "ADK on Docker, optimized with uv"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "adk-docker-uv"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Release version 0.2.0 with template initialization script and package restructure.

## Why

This release includes breaking changes to the package structure and new features that warrant a MINOR version bump (0.1.0 → 0.2.0).

## Changes

### Breaking Changes
- Package restructure: imports changed from nested `agent/` directory to flat structure
- Health endpoint API: response format changed from `{"status": "healthy"}` to `{"status": "ok"}`
- Global instruction system now uses InstructionProvider callable pattern

### New Features
- Template initialization script with dry-run mode and auto package renaming
- InstructionProvider pattern for dynamic instruction generation
- Comprehensive prompt and integration tests

### Improvements
- Simplified documentation structure
- Updated Docker Compose container naming
- Cleaned up obsolete test fixtures