### PR TITLE
fix: prevent replacement race in init script

### DIFF
--- a/init_template.py
+++ b/init_template.py
@@ -460,9 +460,9 @@ def main() -> NoReturn:
 
         # Define replacements
         replacements = {
+            f"https://github.com/{ORIGINAL_GITHUB_OWNER}/{ORIGINAL_REPO_NAME}/": f"https://github.com/{config.github_owner}/{config.repo_name}/",
             ORIGINAL_PACKAGE_NAME: config.package_name,
             ORIGINAL_REPO_NAME: config.repo_name,
-            f"https://github.com/{ORIGINAL_GITHUB_OWNER}/{ORIGINAL_REPO_NAME}/": f"https://github.com/{config.github_owner}/{config.repo_name}/",
         }
 
         # Files to update (paths relative to repo root)


### PR DESCRIPTION
## What
Fixes replacement order race condition in init_template.py

## Why
Badge URL replacement was happening after repo name replacement, causing the pattern to not match. The sequence was:
1. Replace `adk-docker-uv` → `my-agent` (in the badge URL)
2. Try to replace `https://github.com/doughayden/adk-docker-uv/` → doesn't match because URL now contains `my-agent`

## How
- Move badge URL replacement to top of replacements dict
- Ensures badge URL pattern matches before any repo name substitution

## Related
Follow-up to #7