### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-11-20
+
 ### Added
 - CODEOWNERS file with fresh template replacement during init
 - Init script now updates GitHub Actions badge URLs to point to new repository
@@ -73,3 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type checking excludes tests (standard pytest pattern): mypy checks only production code
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
+
+[Unreleased]: https://github.com/doughayden/adk-docker-uv/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/doughayden/adk-docker-uv/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adk-docker-uv"
-version = "0.2.0"
+version = "0.3.0"
 description = "ADK on Docker, optimized with uv"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "adk-docker-uv"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What
Release v0.3.0 with Terraform infrastructure and environment variable updates.

## Why
This release introduces comprehensive Terraform infrastructure-as-code for GCP and GitHub configuration, along with several improvements to the template initialization script and environment variable handling.

## How
- Bump version from 0.2.0 to 0.3.0 in `pyproject.toml`
- Run `uv lock` to update lockfile
- Update `CHANGELOG.md`:
  - Convert [Unreleased] section to [0.3.0] - 2025-11-20
  - Add new empty [Unreleased] section
  - Add version comparison links

## Key Changes in v0.3.0

**New Infrastructure:**
- Terraform bootstrap module for Workload Identity Federation, Artifact Registry, and Reasoning Engine
- Terraform main module for Cloud Run deployment
- Automated GitHub Actions Variables creation
- Artifact Registry cleanup policies with buildcache exemption

**Breaking Changes (pre-1.0 MINOR release):**
- `ARTIFACT_REGISTRY_URL` renamed to `ARTIFACT_REGISTRY_URI`
- `AGENT_ENGINE_URI` simplified to `AGENT_ENGINE` (prefix added in code)

**Improvements:**
- CODEOWNERS file support with template replacement
- Init script updates GitHub Actions badges and resets version
- Improved agent directory discovery with path resolution
- GitHub Actions workflows now use Variables for non-sensitive identifiers

## Version Bump Rationale
MINOR bump (0.2.0 → 0.3.0) following semantic versioning for pre-1.0 releases. While there are breaking changes in environment variable names, pre-1.0 versions allow breaking changes in MINOR releases. The substantial Terraform infrastructure additions warrant a MINOR bump.

## Tests
- [x] Version updated in `pyproject.toml`
- [x] Lockfile updated with `uv lock`
- [x] CHANGELOG updated with release date and comparison links
- [x] All files committed together