### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-11-25
+
 ### Added
 - Reusable CI/CD workflow pattern with three workflows: `ci-cd.yml` (orchestrator), `docker-build.yml` (multi-arch builds), `terraform-plan-apply.yml` (infrastructure deployment)
 - Automatic CI/CD workflow trigger on version tag push (builds Docker images for `v*` tags)
@@ -113,7 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/adk-docker-uv/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/doughayden/adk-docker-uv/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/doughayden/adk-docker-uv/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adk-docker-uv"
-version = "0.3.0"
+version = "0.4.0"
 description = "ADK on Docker, optimized with uv"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "adk-docker-uv"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Release version 0.4.0 with reusable CI/CD workflows, Terraform flexibility improvements, and Cloud Run startup probe resilience.

## Why

This release includes significant CI/CD and infrastructure improvements from PRs #13 and #15, along with documentation updates. Following semantic versioning, this qualifies as a MINOR release due to new backward-compatible features.

## How

- Updated version in pyproject.toml to 0.4.0
- Ran uv lock to update lockfile (Python version bump workflow)
- Converted CHANGELOG.md [Unreleased] section to [0.4.0] - 2025-11-25
- Added new empty [Unreleased] section
- Updated version comparison links

## Key Changes in v0.4.0

**Added:**
- Reusable CI/CD workflow pattern (ci-cd.yml, docker-build.yml, terraform-plan-apply.yml)
- Smart image tagging for PRs and main branch deployments
- PR automation with Terraform plan comments
- Workspace-based Terraform deployment with environment isolation
- Vertex AI Reasoning Engine and GCS artifact storage provisioning
- Docker image recycling pattern for infrastructure-only updates

**Changed:**
- Default Terraform workspace from sandbox to default
- Cloud Run integrates with Vertex AI Reasoning Engine via AGENT_ENGINE

**Fixed:**
- Cloud Run startup probe with HTTP health checks and resilient retry strategy
- Documented IAM bucket access limitations for cross-project scenarios

## Tests

- [x] Version updated in pyproject.toml
- [x] Lockfile updated via uv lock
- [x] CHANGELOG.md properly formatted with new release section
- [x] Version comparison links updated
- [x] All files committed together per Python version bump workflow