### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2025-11-26
+
 ### Changed
 - CI/CD workflows now use image digest (instead of tag) for Cloud Run deployments to ensure every Docker rebuild triggers a new revision deployment, even when tags are reused (e.g., base image security updates, manual rebuilds)
 
@@ -120,7 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/adk-docker-uv/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/doughayden/adk-docker-uv/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/doughayden/adk-docker-uv/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.1.0...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adk-docker-uv"
-version = "0.4.0"
+version = "0.4.1"
 description = "ADK on Docker, optimized with uv"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "adk-docker-uv"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What
Bump version from 0.4.0 to 0.4.1

## Why
Release PATCH version with digest-based Cloud Run deployment improvements from PR #20

## Changes in This Release

- Switch from tag-based to digest-based Cloud Run deployments
- Ensures every Docker rebuild triggers new Cloud Run revision
- Fixes issue where rebuilding same tag didn't trigger redeployment
- Adds comprehensive documentation and traceability guides

## How
- Updated version in `pyproject.toml` to `0.4.1`
- Ran `uv lock` to update lockfile
- Updated `CHANGELOG.md`:
  - Moved `[Unreleased]` changes to `[0.4.1] - 2025-11-26`
  - Added new empty `[Unreleased]` section
  - Updated version comparison links

## Tests
- [x] Version bump follows Python project workflow (both pyproject.toml and uv.lock committed)
- [x] CHANGELOG.md properly formatted with new version section
- [x] Version comparison links updated correctly
- [ ] CI/CD quality checks pass (will verify after PR creation)