### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-11-27
+
 ### Added
 - OpenTelemetry observability with trace export to Google Cloud Trace via OTLP and log export to Cloud Logging with automatic trace correlation
 - Pydantic-based environment configuration (`ServerEnv` model) with type-safe validation and required field enforcement
@@ -150,7 +152,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/adk-docker-uv/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/doughayden/adk-docker-uv/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/doughayden/adk-docker-uv/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/doughayden/adk-docker-uv/compare/v0.2.0...v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adk-docker-uv"
-version = "0.4.1"
+version = "0.5.0"
 description = "ADK on Docker, optimized with uv"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "adk-docker-uv"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## Summary
- Bump version from 0.4.1 to 0.5.0
- Update CHANGELOG.md with release notes for v0.5.0
- Update lockfile via uv lock (required for version bumps)

## Why
This release includes significant new features and improvements:

- OpenTelemetry observability with Google Cloud Trace and Logging integration
- Pydantic-based environment configuration with validation
- Job summaries in CI/CD workflows
- Workspace-based resource naming in Terraform
- Bug fixes for OTEL capture variable and deployment image section

## Changes Included
- chore: bump version to 0.5.0
- fix: add OTEL capture variable to Terraform (#29)
- feat: add OpenTelemetry observability (#28)
- fix: remove primary deployment image section (#26)
- feat: add job summaries to CI/CD workflows (#25)
- docs: condense and correct project documentation (#23)

## Version Bump Rationale
**MINOR (0.5.0)** - Based on semantic versioning:
- New features: OpenTelemetry observability, CI/CD job summaries (backward compatible)
- Bug fixes: OTEL variable configuration, deployment docs cleanup
- No breaking changes
- All changes are backward compatible additions and improvements

## Tests
- [x] Version updated in pyproject.toml
- [x] uv lock ran successfully
- [x] CHANGELOG.md updated with v0.5.0 section
- [x] Version comparison links updated
- [x] Both pyproject.toml and uv.lock committed together