### PR TITLE
fix: move OTEL var to required section

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -37,6 +37,7 @@ jobs:
       TF_VAR_project: ${{ vars.GCP_PROJECT_ID }}
       TF_VAR_location: ${{ vars.GCP_LOCATION }}
       TF_VAR_agent_name: ${{ vars.IMAGE_NAME }}
+      TF_VAR_otel_instrumentation_genai_capture_message_content: ${{ vars.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT }}
       TF_VAR_terraform_state_bucket: ${{ vars.TERRAFORM_STATE_BUCKET }}
       TF_VAR_docker_image: ${{ inputs.docker_image }}
 
@@ -46,7 +47,6 @@ jobs:
       TF_VAR_allow_origins: ${{ vars.ALLOW_ORIGINS }}
       TF_VAR_artifact_service_uri: ${{ vars.ARTIFACT_SERVICE_URI }}
       TF_VAR_log_level: ${{ vars.LOG_LEVEL }}
-      TF_VAR_otel_instrumentation_genai_capture_message_content: ${{ vars.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT }}
       TF_VAR_root_agent_model: ${{ vars.ROOT_AGENT_MODEL }}
       TF_VAR_serve_web_interface: ${{ vars.SERVE_WEB_INTERFACE }}
 


### PR DESCRIPTION
## What
Move `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` from
optional to required variables section in Terraform workflow.

## Why
This variable is required for proper OpenTelemetry configuration and
should be grouped with other required infrastructure variables for
consistency.

## How
- Moved `TF_VAR_otel_instrumentation_genai_capture_message_content`
  from optional section to required section in
  `.github/workflows/terraform-plan-apply.yml`
- Positioned after `TF_VAR_agent_name` for logical grouping

## Tests
- [x] Verified change in workflow file
- [x] Confirmed variable is set via GitHub Variable created by
      Terraform bootstrap