### PR TITLE
docs: use generic placeholders in examples

### DIFF
--- a/docs/docker-compose-workflow.md
+++ b/docs/docker-compose-workflow.md
@@ -209,14 +209,14 @@ If you need to build and run without docker-compose:
 
 ```bash
 # Build the image with BuildKit
-DOCKER_BUILDKIT=1 docker build -t adk-docker-uv:latest .
+DOCKER_BUILDKIT=1 docker build -t your-agent-name:latest .
 
 # Run directly
 docker run \
   -v ./data:/app/data:ro \
   -p 127.0.0.1:8000:8000 \
   --env-file .env \
-  adk-docker-uv:latest
+  your-agent-name:latest
 ```
 
 **Note:** Docker Compose is recommended - it handles volumes, environment, and networking automatically.

--- a/docs/dockerfile-strategy.md
+++ b/docs/dockerfile-strategy.md
@@ -287,11 +287,11 @@ ENV VIRTUAL_ENV=/app/.venv \
 **The Problem:**
 
 When the package is installed in **non-editable mode** (Docker), the source code is copied to the virtual environment's site-packages:
-- Local (editable): `Path(__file__)` → `/path/to/project/src/adk_docker_uv/server.py`
-- Docker (non-editable): `Path(__file__)` → `/app/.venv/lib/python3.13/site-packages/adk_docker_uv/server.py`
+- Local (editable): `Path(__file__)` → `/path/to/project/src/your_agent_name/server.py`
+- Docker (non-editable): `Path(__file__)` → `/app/.venv/lib/python3.13/site-packages/your_agent_name/server.py`
 
 Using `Path(__file__).parent.parent` for `AGENT_DIR`:
-- Local: Resolves to `/path/to/project/src/` ✅ Correct (contains only adk_docker_uv/)
+- Local: Resolves to `/path/to/project/src/` ✅ Correct (contains only your_agent_name/)
 - Docker: Resolves to `/app/.venv/lib/python3.13/site-packages/` ❌ Wrong (contains all packages)
 
 This causes the ADK web UI to show all installed packages (.dist-info directories) instead of just our agent.
@@ -343,7 +343,7 @@ EXPOSE 8000
 ### Startup Command
 ```dockerfile
 # Run the FastAPI server via main() for unified startup logic (logging, etc.)
-CMD ["python", "-m", "adk_docker_uv.server"]
+CMD ["python", "-m", "your_agent_name.server"]
 ```
 **What:** Default command when container starts
 **Why:**

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -77,9 +77,9 @@ OpenTelemetry resource attributes uniquely identify your service instances in tr
 
 | Attribute | Source | Example | Description |
 |-----------|--------|---------|-------------|
-| `service.name` | `AGENT_NAME` env var | `adk-docker-uv` | Service identifier (set explicitly in `.env`) |
+| `service.name` | `AGENT_NAME` env var | `your-agent-name` | Service identifier (set explicitly in `.env`) |
 | `service.namespace` | `TELEMETRY_NAMESPACE` env var | `default`/`dev`/`stage`/`prod` (deployed) or `local` (dev) | Environment (via Terraform workspace) grouping for traces |
-| `service.version` | `K_REVISION` env var | `adk-docker-uv-00042-abc` (deployed) or `local` (dev) | Cloud Run revision or local dev indicator |
+| `service.version` | `K_REVISION` env var | `your-agent-name-00042-abc` (deployed) or `local` (dev) | Cloud Run revision or local dev indicator |
 | `service.instance.id` | Generated | `worker-1234-a1b2c3d4e5f6` | Unique process instance (PID + UUID) |
 | `gcp.project_id` | `GOOGLE_CLOUD_PROJECT` env var | `my-project-id` | GCP project for resource correlation |
 

--- a/docs/terraform-infrastructure.md
+++ b/docs/terraform-infrastructure.md
@@ -58,7 +58,7 @@ cp .env.example .env
 **Required variables:**
 - `GOOGLE_CLOUD_PROJECT` - GCP project ID
 - `GOOGLE_CLOUD_LOCATION` - GCP region (e.g., `us-central1`)
-- `AGENT_NAME` - Your agent name (e.g., `adk-docker-uv`)
+- `AGENT_NAME` - Your agent name (e.g., `your-agent-name`)
 - `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` - Capture LLM content in traces (TRUE/FALSE)
 - `GITHUB_REPO_NAME` - Repository name
 - `GITHUB_REPO_OWNER` - GitHub username or organization
@@ -150,8 +150,8 @@ gh variable list
 # GCP_LOCATION                   us-central1
 # GCP_PROJECT_ID                 your-project-id
 # GCP_WORKLOAD_IDENTITY_PROVIDER projects/.../locations/global/...
-# IMAGE_NAME                     adk-docker-uv
-# TERRAFORM_STATE_BUCKET         terraform-state-adk-docker-uv-a1b2c3d4
+# IMAGE_NAME                     your-agent-name
+# TERRAFORM_STATE_BUCKET         terraform-state-your-agent-name-a1b2c3d4
 ```
 
 ### Security: Dotenv Provider


### PR DESCRIPTION
## What
Replace project-specific names with generic placeholders in documentation examples.

## Why
Template repositories should use generic placeholders rather than specific project names to make it clear what values developers need to customize when creating new projects from the template.

## How
- Replace `adk-docker-uv` with `your-agent-name` (kebab-case) for repository names, Docker image tags, service names, and resource identifiers
- Replace `adk_docker_uv` with `your_agent_name` (snake_case) for Python package names, module references, and file paths
- Ensure consistent naming convention: hyphens for external identifiers (repos, images, services), underscores for Python internals (packages, imports)
- Align placeholder naming with `init_template.py` auto-derivation pattern

## Tests
- [x] Verified all placeholders use consistent naming patterns
- [x] Confirmed kebab-case used for repos/images/services (7 occurrences)
- [x] Confirmed snake_case used for Python packages (4 occurrences)
- [x] No mixed or inconsistent placeholder names remain