### PR TITLE
refactor: change callback log to INFO level

### DIFF
--- a/src/adk_docker_uv/callbacks.py
+++ b/src/adk_docker_uv/callbacks.py
@@ -27,7 +27,7 @@ async def add_session_to_memory(callback_context: CallbackContext) -> None:
         callback_context: The callback context with access to invocation context
     """
     # TODO: use a public attribute (instead of _invocation_context) when available
-    logger.debug("*** Started add_session_to_memory callback ***")
+    logger.info("*** Starting add_session_to_memory callback ***")
     invocation_context = getattr(callback_context, "_invocation_context", None)  # pyright: ignore[reportPrivateUsage]
     if invocation_context:
         if invocation_context.memory_service:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -28,7 +28,7 @@ class TestAddSessionToMemory:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Test that callback saves session when memory service exists."""
-        # Setup logging to capture DEBUG level
+        # Setup logging to capture DEBUG level (to see both INFO and DEBUG logs)
         caplog.set_level(logging.DEBUG)
 
         # Execute callback
@@ -43,7 +43,7 @@ class TestAddSessionToMemory:
         assert saved_session.user_id == "test_user_456"
 
         # Verify logging
-        assert "*** Started add_session_to_memory callback ***" in caplog.text
+        assert "*** Starting add_session_to_memory callback ***" in caplog.text
         assert "Adding session to memory using MockMemoryService" in caplog.text
 
     @pytest.mark.asyncio
@@ -81,8 +81,8 @@ class TestAddSessionToMemory:
         # Verify callback returns None
         assert result is None
 
-        # Verify debug log was created (callback started)
-        assert "*** Started add_session_to_memory callback ***" in caplog.text
+        # Verify info log was created (callback started)
+        assert "*** Starting add_session_to_memory callback ***" in caplog.text
 
         # Verify no warning about missing service (hasattr check prevents this path)
         assert "No memory_service found" not in caplog.text
@@ -132,17 +132,21 @@ class TestAddSessionToMemory:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Test that callback uses appropriate logging levels."""
-        # Test case 1: Saving session (DEBUG level)
+        # Test case 1: Saving session (INFO and DEBUG levels)
         caplog.set_level(logging.DEBUG)
         caplog.clear()
 
         await add_session_to_memory(mock_memory_callback_context)
 
-        # Check for DEBUG logs
+        # Check for INFO log (starting callback)
+        info_records = [r for r in caplog.records if r.levelname == "INFO"]
+        assert len(info_records) == 1
+        assert "Starting add_session_to_memory" in info_records[0].message
+
+        # Check for DEBUG log (adding session)
         debug_records = [r for r in caplog.records if r.levelname == "DEBUG"]
-        assert len(debug_records) == 2  # Started and adding messages
-        assert any("Started add_session_to_memory" in r.message for r in debug_records)
-        assert any("Adding session to memory" in r.message for r in debug_records)
+        assert len(debug_records) == 1
+        assert "Adding session to memory" in debug_records[0].message
 
         # Test case 2: No service (WARNING level)
         caplog.set_level(logging.WARNING)


### PR DESCRIPTION
## What

Changes the `add_session_to_memory` callback entry log from DEBUG to INFO level and updates the log message from "Started" to "Starting".

## Why

The callback entry log at DEBUG level was not visible in default INFO-level logging, making it harder to observe callback execution in production environments. Using INFO level provides better visibility into callback lifecycle without requiring DEBUG logging.

## How

- Changed `logger.debug()` to `logger.info()` for callback entry log in `callbacks.py`
- Updated log message from "Started" to "Starting" for grammatical consistency
- Updated all test assertions in `test_callbacks.py` to expect INFO level
- Updated test expectations to match new "Starting" message text
- Revised test comments to reflect new logging behavior

## Tests

- [x] All existing callback tests pass with updated assertions
- [x] Test coverage for logging levels validates INFO for entry log
- [x] Test coverage for DEBUG level still validates session addition log
- [x] Full test suite passes (71 tests)