### PR TITLE
fix: use PR head SHA instead of merge commit SHA in Docker image tags

### DIFF
--- a/.github/workflows/metadata-extract.yml
+++ b/.github/workflows/metadata-extract.yml
@@ -28,18 +28,19 @@ jobs:
           set -euo pipefail
           REGISTRY="${{ vars.ARTIFACT_REGISTRY_URI }}"
           IMAGE_NAME="${{ vars.IMAGE_NAME }}"
-          SHA_SHORT=$(git rev-parse --short HEAD)
 
           # Determine tags based on context (deployment uses digest, not tags)
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # PR build - use pr-{number}-{sha} (unique per commit, clearly indicates origin)
+            # PR build - use PR head SHA (not merge commit) for traceability
+            SHA_SHORT=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
             PR_TAG="pr-${{ github.event.pull_request.number }}-${SHA_SHORT}"
             IMAGE_URI="${REGISTRY}/${IMAGE_NAME}:${PR_TAG}"
             TAGS="${IMAGE_URI}"
           else
-            # Main branch or manual - build multiple tags (SHA, latest, version if available)
+            # Main branch or manual - use actual commit SHA
+            SHA_SHORT=$(git rev-parse --short HEAD)
+            # Build all tags: SHA (for traceability), latest, version if available
             IMAGE_URI="${REGISTRY}/${IMAGE_NAME}:${SHA_SHORT}"
-            # Build all tags: SHA (for traceability), latest, version (if available)
             TAGS="${IMAGE_URI},${REGISTRY}/${IMAGE_NAME}:latest"
             # Add semantic version tag if available
             if VERSION=$(git describe --tags --exact-match 2>/dev/null); then
@@ -52,7 +53,13 @@ jobs:
       - name: Generate Job Summary
         run: |
           set -euo pipefail
-          SHA_SHORT=$(git rev-parse --short HEAD)
+
+          # Use PR head SHA for PRs, git rev-parse for everything else
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            SHA_SHORT=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          else
+            SHA_SHORT=$(git rev-parse --short HEAD)
+          fi
 
           cat >> $GITHUB_STEP_SUMMARY << EOF
           ## 📦 Build Metadata


### PR DESCRIPTION
## What
Use the actual PR head commit SHA instead of GitHub's temporary merge commit SHA when tagging Docker images for PR builds.

## Why
Docker image tags for PR builds currently use GitHub's temporary merge commit SHA (created by GitHub Actions), making it difficult to trace images back to specific commits in the repository history.

**Example from PR #42:**
- Previous tag: pr-42-1e1a897 (merge commit - doesn't exist in repo)
- Actual commit: 735f6d5 (fix: correct typo in README)
- With this fix: pr-42-735f6d5 (traceable in git log)

## How
**In .github/workflows/metadata-extract.yml:**
- For PR builds: Use github.event.pull_request.head.sha from GitHub context
- For main branch builds: Continue using git rev-parse --short HEAD (unchanged)
- Updated both "Extract metadata" and "Generate Job Summary" steps

**Changes:**
- PR builds now extract SHA using echo github.event.pull_request.head.sha cut -c1-7
- Main branch logic unchanged (already uses correct SHA)
- Added comments clarifying PR vs main branch SHA extraction

## Tests
This PR itself will verify the fix:
- [ ] Check workflow run logs show PR head SHA matching commit in this PR
- [ ] Verify image tag in registry uses actual commit SHA (not merge commit)
- [ ] Confirm git log --oneline shows the SHA used in the tag
- [ ] Verify main branch builds still work correctly after merge

## Impact
**Low risk:**
- Change only affects tag naming, not image contents or deployment
- Images are deployed by digest (immutable), not by tag
- Main branch logic unchanged
- Tag format remains the same: pr-{number}-{sha}

## Related Issues
Closes #44