### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-12-07
+
 ### Fixed
 - Use PR head SHA instead of GitHub's temporary merge commit SHA for Docker image tags, improving traceability to actual commits in repository history
 - Move OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT to required section in Terraform variables
@@ -180,7 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/doughayden/agent-foundation/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/doughayden/agent-foundation/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/doughayden/agent-foundation/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/doughayden/agent-foundation/compare/v0.3.0...v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.5.0"
+version = "0.6.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "agent-foundation"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What
Version bump to 0.6.0 with updated CHANGELOG

## Why
Release accumulated fixes, improvements, and breaking project rename from adk-docker-uv to agent-foundation

## How
- Update version in pyproject.toml from 0.5.0 to 0.6.0
- Run uv lock to update lockfile
- Convert CHANGELOG.md [Unreleased] section to [0.6.0] - 2025-12-07
- Add new empty [Unreleased] section
- Update version comparison links

## Key Changes in This Release

### Breaking Changes
- **Project rename**: adk-docker-uv → agent-foundation
  - Repository, package, Docker images, imports, and all documentation updated
  - This is a breaking change for existing deployments

### Fixes
- Use PR head SHA for Docker image tags (improves commit traceability)
- Fix workload identity federation resource ID collisions
- Truncate service account IDs to enforce GCP 30-char limit
- Move OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT to required section in Terraform

### Documentation
- New bootstrap setup guide (docs/bootstrap-setup.md)
- Comprehensive environment variables reference (docs/environment-variables.md)
- Naming consistency updates (ADK agent → LLM agent)
- Streamlined README (38% reduction) and development guide (48% reduction)
- Optimized CLAUDE.md for AI consumption (36% reduction)