### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-12-11
+
 ### Changed
 - **BREAKING**: Upgrade to google-adk 1.20.0 and migrate to App and plugin pattern for improved modularity and ADK best practices
   - Agent now wrapped in `App` container with `GlobalInstructionPlugin` for dynamic instruction generation and `LoggingPlugin` for agent lifecycle logging
@@ -190,7 +192,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/doughayden/agent-foundation/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/doughayden/agent-foundation/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/doughayden/agent-foundation/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/doughayden/agent-foundation/compare/v0.4.0...v0.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.6.0"
+version = "0.7.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "agent-foundation"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Prepare release v0.7.0 with version bump and changelog updates.

## Why

Ready to release the ADK 1.20.0 upgrade and App pattern migration.

## How

- Updated version to 0.7.0 in pyproject.toml
- Ran `uv lock` to sync lockfile
- Converted [Unreleased] to [0.7.0] - 2025-12-11 in CHANGELOG.md
- Added new empty [Unreleased] section
- Updated version comparison links

## Tests

- [x] Version correctly updated in pyproject.toml and uv.lock
- [x] CHANGELOG.md properly formatted with new version entry
- [x] Version comparison links updated