### PR TITLE
fix: add spec to reasoning engine resource

### DIFF
--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -75,7 +75,7 @@ resource "google_project_iam_member" "app" {
 resource "google_vertex_ai_reasoning_engine" "session_and_memory" {
   display_name = "${local.resource_name} Sessions and Memory"
   description  = "Managed Session and Memory Bank Service for the ${local.resource_name} app"
-  
+
   # Prevent plan and apply diffs with an empty spec for managed sessions and memory bank only (no runtime code)
   spec {}
 }


### PR DESCRIPTION
## What
Adds an empty `spec` block to the Vertex AI Reasoning Engine resource configuration

## Why
Prevents plan/apply diffs when using the reasoning engine solely for managed sessions and memory bank service (without custom runtime code)

## How
- Add empty `spec {}` block to `google_vertex_ai_reasoning_engine` resource
- Include explanatory comment for future maintainers

## Tests
- [ ] Verify terraform plan shows no changes after apply
- [ ] Confirm reasoning engine continues to work for session/memory management