### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2025-12-12
+
 ### Changed
 - **BREAKING**: Move GitHub repository configuration from `.env` to `terraform/bootstrap/terraform.tfvars` for cleaner separation of infrastructure config from application runtime config
   - `GITHUB_REPO_OWNER` → `repository_owner` in terraform.tfvars
@@ -204,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/doughayden/agent-foundation/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/doughayden/agent-foundation/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/doughayden/agent-foundation/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/doughayden/agent-foundation/compare/v0.4.1...v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.7.0"
+version = "0.8.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "agent-foundation"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What
Release version 0.8.0 with breaking changes to infrastructure configuration and local development requirements.

## Why
This release formalizes the separation of infrastructure configuration from runtime configuration and enforces the deploy-first workflow pattern that ensures users test the full deployment pipeline early.

## How
- Bump version from 0.7.0 to 0.8.0 in pyproject.toml
- Update uv.lock to reflect version change
- Update CHANGELOG.md:
  - Convert [Unreleased] section to [0.8.0] - 2025-12-12
  - Add new empty [Unreleased] section
  - Update version comparison links

## Breaking Changes

### Infrastructure Configuration
- GitHub repository configuration moved from `.env` to `terraform/bootstrap/terraform.tfvars`
  - `GITHUB_REPO_OWNER` → `repository_owner` in terraform.tfvars
  - `GITHUB_REPO_NAME` → `repository_name` in terraform.tfvars
  - Bootstrap Terraform module now requires explicit tfvars (no .env fallback)

### Local Development Requirements
- `AGENT_ENGINE` and `ARTIFACT_SERVICE_URI` are now **required** (previously optional)
- Local development now requires completed deployment to cloud
- This change enforces the deploy-first workflow and ensures users test the full deployment pipeline early

## Related Issues
Closes #57