### PR TITLE
docs: condense CLAUDE.md and enhance template docs

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Terraform Plan
         id: plan
         working-directory: terraform/main
-        shell: bash {0}  # removes -e flag to allow capturing output on failure
+        shell: bash {0}  # Removes -e flag to allow capturing output on failure
         run: |
           terraform workspace select --or-create ${{ inputs.workspace }}
           WORKSPACE=$(terraform workspace show)
@@ -191,7 +191,7 @@ jobs:
         id: apply
         if: inputs.terraform_action == 'apply'
         working-directory: terraform/main
-        shell: bash {0}  # Allow capturing output on failure
+        shell: bash {0}  # Removes -e flag to allow capturing output on failure
         run: |
           terraform workspace select ${{ inputs.workspace }}
           WORKSPACE=$(terraform workspace show)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See [Development Guide](docs/base-infra/development.md) for workflow, testing, a
 
 ---
 
-## CI/CD Infrastructure Setup
+## Setup and Deployment
 
 Provision CI/CD infrastructure and deploy cloud resources.
 
@@ -83,13 +83,11 @@ Provision CI/CD infrastructure and deploy cloud resources.
 
 ### Bootstrap CI/CD Infrastructure
 
-Set up the foundation for automated deployments:
-
 ```bash
-# 0. Initialize from template (if using as template)
-uv run init_template.py  # Only if using as GitHub template; --dry-run to preview
+# 0. Initialize from template
+uv run init_template.py  # --dry-run to preview changes
 # Renames package, updates configs/docs, resets changelog, writes log: `init_template_results.md` (gitignored)
-# Delete init_template.py, init_template_results.md, and this step (README Bootstrap 0.) after initialization
+# After initialization, delete: init_template.py, init_template_results.md, and this step (README Bootstrap 0.)
 git add -A && git commit -m "chore: initialize from template"
 
 # 1. Configure app runtime environment

--- a/docs/base-infra/development.md
+++ b/docs/base-infra/development.md
@@ -176,7 +176,6 @@ your-agent-name/
   pyproject.toml          # Project configuration
   docker-compose.yml      # Local development
   Dockerfile              # Container image
-  init_template.py        # Template initialization
   CLAUDE.md               # Project instructions
   README.md               # Main documentation
 ```

--- a/init_template.py
+++ b/init_template.py
@@ -1,29 +1,60 @@
 """Initialize repository from template.
 
-⚠️ NOTE: This is a one-time use initialization script, NOT part of the package.
-- Excluded from test coverage (not in src/, runs once per repo clone)
-- Excluded from ruff/mypy checks (see pyproject.toml)
-- No automated tests required (manual validation via --dry-run mode)
+⚠️ ONE-TIME USE SCRIPT - Delete after running!
 
-This script automates the package name replacement process when creating
-a new repository from the template. Run once after creating from template:
+This script customizes your repository after creating from the template.
+It auto-detects the new repository info from git and performs all necessary renames.
 
+USAGE:
+    # Preview changes (no modifications)
+    uv run init_template.py --dry-run
+
+    # Apply changes
     uv run init_template.py
 
-The script performs:
-- Directory renaming (src/agent_foundation → src/{package_name})
-- File content updates (package imports, configuration, documentation)
-- GitHub Actions badge URL updates
-- CODEOWNERS replacement with fresh template
-- Version reset to 0.1.0 in pyproject.toml
-- CHANGELOG.md replacement with fresh template
-- UV lockfile regeneration
+REQUIREMENTS:
+    - Git repository with configured remote (clone from GitHub, not local init)
+    - Repository name must be kebab-case (lowercase, hyphens only)
+    - Examples: my-agent, cool-app-v2, data-processor
 
-Reusing in other template projects:
-    To adapt this script for another template repository, update the constants:
-    - ORIGINAL_PACKAGE_NAME: The original Python package name (snake_case)
-    - ORIGINAL_REPO_NAME: The original repository name (kebab-case)
-    - ORIGINAL_GITHUB_OWNER: The original GitHub owner/organization
+WHAT IT DOES:
+    1. Auto-detects YOUR new repository owner/name from git remote URL
+    2. Validates repository name is kebab-case (enforces Python naming)
+    3. Derives package name (my-agent → my_agent)
+    4. Replaces template names with yours:
+       - agent_foundation → your_package_name
+       - agent-foundation → your-repo-name
+       - template-owner/agent-foundation → your-owner/your-repo
+    5. Renames src/agent_foundation/ → src/{package_name}/
+    6. Updates imports, config, and docs in all files
+    7. Updates GitHub Actions badge URLs
+    8. Resets CODEOWNERS file (remove template owner)
+    9. Resets version to 0.1.0 in pyproject.toml
+    10. Resets CHANGELOG.md with clean template
+    11. Regenerates UV lockfile
+
+OUTPUT:
+    Creates init_template_results.md (or init_template_dry_run.md) with
+    detailed log of all changes. Review this file to verify changes.
+
+AFTER RUNNING:
+    1. Review: git status
+    2. Delete this script: rm init_template.py
+    3. Delete log file: rm init_template_results.md
+    4. Update README.md and CLAUDE.md to remove template initialization section
+    5. Configure .env: cp .env.example .env (add your GCP details)
+    6. Commit: git add -A && git commit -m "chore: initialize from template"
+
+REUSING IN OTHER TEMPLATES:
+    To adapt this script for a different template repository, update:
+    - ORIGINAL_PACKAGE_NAME: Original Python package (snake_case)
+    - ORIGINAL_REPO_NAME: Original repository name (kebab-case)
+    - ORIGINAL_GITHUB_OWNER: Original GitHub owner/organization
+
+TECHNICAL NOTES:
+    - Excluded from test coverage (not in src/, one-time use)
+    - Excluded from ruff/mypy checks (see pyproject.toml)
+    - No automated tests (manual validation via --dry-run)
 """
 
 import re


### PR DESCRIPTION
## What

Optimize CLAUDE.md for efficient Claude Code context consumption and improve template initialization documentation.

## Why

CLAUDE.md had grown to 303 lines with verbose user-facing documentation content instead of being optimized as dense, technical context for Claude Code sessions. The template initialization documentation was scattered and redundant across multiple files.

## How

**CLAUDE.md optimization:**
- Condensed from 303 to 113 lines (63% reduction) using memorizer agent
- Converted verbose explanations to dense technical summaries
- Restructured content prioritizing critical info first (branch protection, version bumps, quick commands)
- Preserved all essential project-specific patterns and conventions
- Maintained references to detailed documentation in docs/base-infra/

**Template initialization improvements:**
- Enhanced init_template.py docstring with comprehensive self-documenting guide
- Added complete USAGE, REQUIREMENTS, WHAT IT DOES, OUTPUT, AFTER RUNNING sections
- Included explicit cleanup instructions (delete script, log, README/CLAUDE.md sections)
- Clarified auto-detection behavior (detects new repo from git remote, not template)
- Simplified README.md bootstrap step 0 (removed redundant parentheticals)
- Removed init_template.py reference from development.md project structure

**Consistency fixes:**
- Standardized terraform workflow comment capitalization
- Ensured cleanup instructions consistent across all files

## Tests

- [x] CLAUDE.md condensed while preserving all critical technical context
- [x] Template initialization cleanup instructions consistent across files
- [x] init_template.py docstring provides complete standalone documentation
- [x] README.md template section streamlined and clear