### PR TITLE
chore: prepare release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-02-19
+
 ### Changed
 - Upgrade google-adk from 1.21.0 to 1.25.1 with transitive deps
 - Update .gitignore for google-adk v1.20.0+ storage (.adk/)
@@ -256,7 +258,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/doughayden/agent-foundation/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/doughayden/agent-foundation/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/doughayden/agent-foundation/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/doughayden/agent-foundation/compare/v0.6.0...v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.9.0"
+version = "0.9.1"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "agent-foundation"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What
Prepare release v0.9.1 with version bump and CHANGELOG update.

## Why
Release patch version for google-adk upgrade and related fixes.

## How
- Update version in pyproject.toml to 0.9.1
- Run uv lock to update lockfile
- Convert CHANGELOG [Unreleased] to [0.9.1] - 2026-02-19
- Update comparison links for v0.9.1

## Tests
- [x] Version updated correctly
- [x] Lockfile synchronized
- [x] CHANGELOG follows Keep a Changelog format