### PR TITLE
docs: improve template management guide

### DIFF
--- a/docs/template-management.md
+++ b/docs/template-management.md
@@ -147,9 +147,9 @@ Sync strategy by file type. Complete [Setup](#setup) and [Prepare](#prepare) to 
 ```bash
 git checkout foundation-tags/$VERSION -- .github/workflows/
 git checkout foundation-tags/$VERSION -- terraform/
-git checkout foundation-tags/$VERSION -- docs/
+git checkout foundation-tags/$VERSION -- docs/ mkdocs.yml
 git checkout foundation-tags/$VERSION -- notebooks/
-git checkout foundation-tags/$VERSION -- .gitignore .dockerignore mkdocs.yml
+git checkout foundation-tags/$VERSION -- .gitignore .dockerignore
 # Review: git status && git diff --cached
 ```
 
@@ -162,14 +162,6 @@ git diff foundation-tags/$VERSION -- Dockerfile docker-compose.yml .env.example
 git diff foundation-tags/$VERSION -- pyproject.toml
 ```
 
-**Never sync (your code):**
-- `src/` - Your agent implementation
-- `tests/` - Your test suite
-- `CHANGELOG.md` - Your version history
-- `init_template.py` - Removed from your project after first use
-- `LICENSE` - Your project license
-- `uv.lock` - Regenerate with `uv lock` after syncing pyproject.toml
-
 **Review upstream patterns (apply manually):**
 
 Foundation may enhance reusable code patterns. Review diffs and selectively apply improvements:
@@ -181,6 +173,14 @@ git diff foundation-tags/$VERSION -- src/agent_foundation/utils/
 # Review test patterns (pytest fixtures, ADK mocks)
 git diff foundation-tags/$VERSION -- tests/conftest.py
 ```
+
+**Never sync (your code):**
+- `src/` - Your agent implementation
+- `tests/` - Your test suite
+- `CHANGELOG.md` - Your version history
+- `init_template.py` - Removed from your project after first use
+- `LICENSE` - Your project license
+- `uv.lock` - Regenerate with `uv lock` after syncing pyproject.toml
 
 > [!WARNING]
 > After syncing `pyproject.toml`, run `uv lock` to regenerate lockfile. Never sync `uv.lock` - CI uses `uv sync --locked` which fails on stale lockfile.


### PR DESCRIPTION
## What

Comprehensive improvements to the template management documentation for better usability and technical accuracy.

## Why

The original guide had several issues:
- Technical inaccuracy: claimed `git checkout` deletes untracked local files (it doesn't)
- Lacked copy-paste workflow - users had to manually replace version strings throughout
- Missing quick reference for common sync operations
- Intimidating for first-time users with no roadmap
- Workflow steps lacked semantic grouping

## How

- Add roadmap tip directing first-time users to essential vs optional sections
- Restructure workflow into semantic phases: Prepare → Sync → Review → Test & Merge
- Introduce `$VERSION` shell variable pattern for copy-pasteable commands throughout
- Add "Quick Reference" section with sync strategy organized by file type
- Fix git checkout warning to accurately describe behavior (stages files, doesn't delete untracked)
- Add NOTE alert highlighting terraform/ and docs/ customizations
- Enhance Common Patterns with clearer examples and proper alerts
- Improve Troubleshooting section with CAUTION alerts for destructive commands
- Remove redundant "Sync Safety" section content now covered in Quick Reference

## Tests

- [x] Documentation renders correctly in GitHub markdown
- [x] All internal links work (Setup, Prepare, Sync, Review, Test & Merge, Common Patterns, Troubleshooting)
- [x] Code blocks are copy-pasteable with $VERSION variable
- [x] Alerts display properly (TIP, NOTE, WARNING, CAUTION)
- [x] MkDocs nav structure improved with semantic grouping