### PR TITLE
chore: prepare release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-02-20
+
+### Changed
+- Restructure template management guide with semantic workflow phases (Prepare/Sync/Review/Test & Merge)
+- Add Quick Reference section with copy-paste sync commands organized by file type
+- Introduce VERSION shell variable pattern for streamlined workflow
+- Add roadmap tip directing first-time users to essential sections
+- Enhance Common Patterns and Troubleshooting sections with proper alert styling
+
+### Fixed
+- Correct git checkout behavior warning (does not delete untracked local files)
+- Add .adk/ directory to .dockerignore for ADK v1.20.0+ compatibility
+- Clarify RELOAD_AGENTS comment in .env.example
+
 ## [0.9.1] - 2026-02-19
 
 ### Changed
@@ -258,7 +272,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/doughayden/agent-foundation/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/doughayden/agent-foundation/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/doughayden/agent-foundation/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/doughayden/agent-foundation/compare/v0.7.0...v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.9.1"
+version = "0.9.2"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "agent-foundation"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Prepare v0.9.2 release with template management guide improvements.

## Why

Package the comprehensive template sync documentation improvements for downstream repository synchronization.

## How

- Update version to 0.9.2 in pyproject.toml
- Regenerate uv.lock with version bump
- Update CHANGELOG.md with v0.9.2 release notes:
  - Restructured template management guide with semantic workflow phases
  - Added Quick Reference section with copy-paste commands
  - Introduced VERSION shell variable pattern
  - Fixed git checkout behavior documentation
  - Enhanced Common Patterns and Troubleshooting sections

## Tests

- [x] Version updated in pyproject.toml (0.9.1 → 0.9.2)
- [x] uv.lock regenerated successfully
- [x] CHANGELOG.md follows Keep a Changelog format
- [x] Comparison links updated correctly