### PR TITLE
refactor: clarify terraform resources and examples

### DIFF
--- a/terraform/main/backend.tf
+++ b/terraform/main/backend.tf
@@ -1,6 +1,6 @@
 # GCS partial backend for Terraform state
 # Bucket name passed via -backend-config during terraform init
-# Example (local): terraform -chdir=terraform/main init -backend-config="bucket=$(terraform -chdir=terraform/bootstrap output -raw terraform_state_bucket)"
+# Example (local): terraform -chdir=terraform/main init -backend-config="bucket=$(terraform -chdir=terraform/bootstrap/dev output -raw terraform_state_bucket)"
 # Example (CI/CD): terraform init -backend-config="bucket=${{ vars.TERRAFORM_STATE_BUCKET }}"
 terraform {
   backend "gcs" {

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -74,6 +74,7 @@ resource "google_project_iam_member" "app" {
 resource "google_vertex_ai_reasoning_engine" "session_and_memory" {
   display_name = "${local.resource_name} Sessions and Memory"
   description  = "Managed Session and Memory Bank Service for the ${local.resource_name} app"
+  region       = var.location
 
   # Prevent plan and apply diffs with an empty spec for managed sessions and memory bank only (no runtime code)
   spec {}
@@ -162,7 +163,7 @@ resource "google_cloud_run_v2_service" "app" {
 # Read Cloud Run service state after resource modification completes to work around GCP API eventual
 # consistency - Terraform's dependency graph ensures this data source is read after the resource is
 # updated, guaranteeing outputs reflect the actual deployed revision rather than stale cached data.
-data "google_cloud_run_v2_service" "app_actual" {
+data "google_cloud_run_v2_service" "app" {
   for_each = local.locations
   name     = google_cloud_run_v2_service.app[each.key].name
   location = each.key

--- a/terraform/main/outputs.tf
+++ b/terraform/main/outputs.tf
@@ -45,7 +45,7 @@ output "artifact_service_uri" {
 
 output "cloud_run_services" {
   description = "Agent app Cloud Run service details per location"
-  value = { for loc, svc in data.google_cloud_run_v2_service.app_actual :
+  value = { for loc, svc in data.google_cloud_run_v2_service.app :
     loc => {
       latest_ready_revision = split("revisions/", svc.latest_ready_revision)[1]
       update_time           = svc.update_time

--- a/terraform/main/terraform.tfvars.example
+++ b/terraform/main/terraform.tfvars.example
@@ -1,6 +1,7 @@
 ### ===========================================
 ### Shared Configuration
 ### ===========================================
+environment                                        = "dev"
 project                                            = "project-id"
 location                                           = "us-central1"
 agent_name                                         = "agent-name"


### PR DESCRIPTION
## What

Improves clarity of Terraform resources and updates examples to match the current multi-environment bootstrap structure.

## Why

- The Vertex AI Reasoning Engine resource was missing an explicit region parameter
- The data source name `app_actual` was unclear and inconsistent with standard naming
- Bootstrap path examples referenced the old single-environment structure instead of the current `terraform/bootstrap/dev` structure
- The terraform.tfvars.example was missing the required environment variable

## How

- Add explicit `region = var.location` parameter to `google_vertex_ai_reasoning_engine.session_and_memory` resource
- Rename data source from `app_actual` to `app` for consistency and clarity
- Update backend.tf comment example to use `terraform/bootstrap/dev` path
- Add `environment = "dev"` to terraform.tfvars.example

## Tests

- [ ] Verify terraform plan shows no unexpected changes with the renamed data source
- [ ] Confirm bootstrap path example in backend.tf is accurate for multi-environment structure
- [ ] Validate terraform.tfvars.example includes all required variables