### PR TITLE
chore: prepare release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-02-23
+
+### Changed
+- Use AGENTS.md for portable AI assistant project memory
+- Refactor package initialization to use PEP 562 lazy loading pattern for improved ADK compatibility
+- Clarify Terraform resource configuration with explicit region parameter and cleaner naming
+
 ### Fixed
 - Support ADK eval command with PEP 562 lazy loading pattern
 
@@ -275,7 +282,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/doughayden/agent-foundation/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/doughayden/agent-foundation/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/doughayden/agent-foundation/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/doughayden/agent-foundation/compare/v0.8.0...v0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.9.2"
+version = "0.9.3"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "agent-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What
Prepare patch release v0.9.3 for PEP 562 lazy loading and AGENTS.md portability improvements.

## Why
This release includes:
- PEP 562 lazy loading pattern for ADK eval command compatibility
- AGENTS.md extraction for worktree-compatible template management
- Terraform resource clarifications

## How
- Bump version from 0.9.2 to 0.9.3 in pyproject.toml
- Update uv.lock
- Convert [Unreleased] to [0.9.3] in CHANGELOG.md
- Update changelog comparison links

## Tests
- [x] Version updated in pyproject.toml
- [x] Lockfile updated with uv lock
- [x] CHANGELOG.md updated with release date
- [x] Comparison links updated