### PR TITLE
chore: prepare release v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-02-25
+
+### Changed
+- Refine developer journey across README, getting-started, infrastructure, and reference docs
+
 ## [0.9.3] - 2026-02-23
 
 ### Changed
@@ -282,7 +287,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.3...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/doughayden/agent-foundation/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/doughayden/agent-foundation/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/doughayden/agent-foundation/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/doughayden/agent-foundation/compare/v0.9.0...v0.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.9.3"
+version = "0.9.4"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "agent-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What
Prepare patch release v0.9.4.

## Why
Cut sync target for downstream repos following docs improvements in #92.

## How
- Bump version to 0.9.4 in `pyproject.toml`
- Update `uv.lock`
- Update `CHANGELOG.md`: convert [Unreleased] to v0.9.4, add comparison links

## Tests
- [ ] All 62 tests pass, 100% coverage
- [ ] ruff format, ruff check, mypy all clean