### PR TITLE
chore: prepare release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-03-01
+
 ### Added
 - `terraform/bootstrap/pre/` module creates GCS state buckets (one per environment) before bootstrap — supports incremental provisioning
 - `terraform/main/services.tf` — consumer extension point for additional GCP API enablement; `time_sleep.service_enablement_propagation` (120s, `for_each` per service) guards against async backend initialization after API enablement
@@ -297,7 +299,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/doughayden/agent-foundation/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/doughayden/agent-foundation/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/doughayden/agent-foundation/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/doughayden/agent-foundation/compare/v0.9.1...v0.9.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.9.4"
+version = "0.10.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "agent-foundation"
-version = "0.9.4"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Version bump to v0.10.0 with changelog conversion.

## Why

Minor release capturing two new features: pre-bootstrap remote state and main module extension points for GCP APIs and WIF IAM roles.

## How

- Bump version in `pyproject.toml` to `0.10.0`
- Run `uv lock` to update lockfile
- Convert `[Unreleased]` to `[0.10.0] - 2026-03-01` in `CHANGELOG.md`
- Update comparison links

## Tests

- [x] `ruff format`, `ruff check`, `mypy` — all pass
- [x] `pytest --cov` — 62 passed, 100% coverage