### PR TITLE
docs: point consumers at ADK model selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ Entry-point map for "I want to add X". Each row points to the file where the cha
 | Enable a GCP API | `terraform/main/services.tf` | `google_project_service`; downstream resources `depends_on = [time_sleep.service_enablement_propagation["api.googleapis.com"]]` |
 | Grant a WIF role | `terraform/main/iam.tf` | `google_project_iam_member`; downstream resources `depends_on = [time_sleep.wif_iam_propagation["roles/example"]]` |
 | Override runtime config | GitHub Environment Variables → `TF_VAR_*` | See `coalesce()` call sites in `terraform/main/` for current overridable surface |
+| Swap the LLM | `ROOT_AGENT_MODEL` in `agent.py` | Gemini/Claude/Vertex-hosted work via model string out of the box. For LiteLlm / Apigee / Ollama / vLLM / LiteRT-LM connectors, install the matching ADK extra and pass a connector instance. See [ADK models](https://adk.dev/agents/models/). |
 
 **Template internals** (higher upstream-sync cost if customized — consumers may still modify, but expect merge complexity on future upstream syncs):
 - `terraform/bootstrap/` — bootstrap roots and shared modules


### PR DESCRIPTION
## What
Adds a single row to the Consumer Extension Points table in \`AGENTS.md\` pointing consumers to ADK's model documentation for swapping the LLM.

## Why
Closes #127. After review feedback, the right approach is to treat model selection as a **consumer concern** rather than a template concern:

- \`ROOT_AGENT_MODEL\` is a constant consumers swap to fit their needs — Gemini is the default we ship, not the only option
- Supply-chain liability (litellm) doesn't belong in the base template; consumers decide their own risk posture
- ADK owns and tests \`LiteLlm\`; our testing philosophy covers only our code
- Docs would drift — Google owns the MaaS prerequisite and capability docs; AGENTS.md's "pointer over enumeration" principle applies here

## How
One row added to the Consumer Extension Points table in \`AGENTS.md\`:

| Swap the LLM | \`ROOT_AGENT_MODEL\` in \`agent.py\` | Gemini/Claude/Vertex-hosted work via model string out of the box. For LiteLlm / Apigee / Ollama / vLLM / LiteRT-LM connectors, install the matching ADK extra and pass a connector instance. See [ADK models](https://adk.dev/agents/models/). |

No code, dependency, or other documentation changes.

## Tests
- [x] \`uv run ruff format && uv run ruff check --fix\` — all checks passed
- [x] \`uv run mypy\` — no issues found
- [x] \`uv run pytest --cov\` — 74 passed, 100% coverage

## Related Issues
Closes #127