### PR TITLE
feat: backport kairos fixes and tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ Source package lives under `src/` (single package — file references below use 
 
 **Module roles:** `agent.py` (composition), `tools.py` / `callbacks.py` / `prompt.py` (consumer extension points — see Consumer Extension Points), `server.py` (FastAPI + ADK via `get_fast_api_app()`), `utils/config.py` (Pydantic `ServerEnv`, type-safe fail-fast), `utils/observability.py` (OpenTelemetry init).
 
+**Memory:** Read via the `load_memory` function tool (LLM queries on-demand; ADK auto-appends a usage instruction when the tool is registered). Write via the `add_session_to_memory` after-agent callback.
+
 **Session Service:** Cloud SQL Postgres (private IP) via ADK `DatabaseSessionService`.
 - `get_fast_api_app()` routes `postgresql://` URIs automatically — no application code needed
 - Connection via Cloud SQL Auth Proxy sidecar (IAM auth, no passwords)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Replace `PreloadMemoryTool` with the `load_memory` function tool in `agent.py` — memory is now retrieved on-demand when the LLM decides it is needed, rather than eager-preloaded into context on every turn (#150)
+- Add explicit empty-password colon to `SESSION_SERVICE_URI` in `terraform/main/main.tf` (`user@` → `user:@`) to align with the documented example in `docs/environment-variables.md` and self-document intentional empty password under IAM database auth (#150)
+- Document memory read/write paths in AGENTS.md Architecture Overview (`load_memory` tool with auto-appended ADK instruction; `add_session_to_memory` after-agent callback) (#150)
+
+### Removed
+- Stale `PydanticDeprecatedSince212` warning filter from `pyproject.toml` — no longer triggered by current dependencies (#150)
+
 ## [0.12.4] - 2026-04-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,9 +136,6 @@ directory = "htmlcov"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-filterwarnings = [
-    "ignore::pydantic.warnings.PydanticDeprecatedSince212:google.genai.types",
-]
 # Uncomment to enable live logging for debugging API calls
 # log_cli = true
 # log_cli_level = "DEBUG"

--- a/src/agent_foundation/agent.py
+++ b/src/agent_foundation/agent.py
@@ -4,8 +4,7 @@ from google.adk.agents import LlmAgent
 from google.adk.apps import App
 from google.adk.plugins.global_instruction_plugin import GlobalInstructionPlugin
 from google.adk.plugins.logging_plugin import LoggingPlugin
-from google.adk.tools import FunctionTool
-from google.adk.tools.preload_memory_tool import PreloadMemoryTool
+from google.adk.tools import FunctionTool, load_memory
 
 from .callbacks import LoggingCallbacks, add_session_to_memory
 from .prompt import (
@@ -28,7 +27,7 @@ root_agent = LlmAgent(
     after_agent_callback=[logging_callbacks.after_agent, add_session_to_memory],
     model=ROOT_AGENT_MODEL,
     instruction=ROOT_AGENT_INSTRUCTION,
-    tools=[PreloadMemoryTool(), FunctionTool(get_current_time)],
+    tools=[FunctionTool(get_current_time), load_memory],
     before_model_callback=logging_callbacks.before_model,
     after_model_callback=logging_callbacks.after_model,
     before_tool_callback=logging_callbacks.before_tool,

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -39,7 +39,7 @@ locals {
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = coalesce(var.otel_instrumentation_genai_capture_message_content, "FALSE")
     RELOAD_AGENTS                                      = "FALSE"
     SERVE_WEB_INTERFACE                                = coalesce(var.serve_web_interface, "FALSE")
-    SESSION_SERVICE_URI                                = "postgresql+asyncpg://${google_sql_user.app.name}@localhost:5432/${google_sql_database.sessions.name}"
+    SESSION_SERVICE_URI                                = "postgresql+asyncpg://${google_sql_user.app.name}:@localhost:5432/${google_sql_database.sessions.name}"
     TELEMETRY_NAMESPACE                                = var.environment
   }
 

--- a/tests/test_logging_callbacks.py
+++ b/tests/test_logging_callbacks.py
@@ -25,6 +25,7 @@ class TestLoggerInjection:
         callbacks = LoggingCallbacks()
 
         assert callbacks.logger is not None
+        assert callbacks.logger.name == "agent_foundation.callbacks"
 
     def test_logging_callbacks_custom_logger(
         self, custom_logger: logging.Logger


### PR DESCRIPTION
## What

Small batch of downstream fixes/enhancements backported from kairos to serve as the latest agent-foundation sync point.

## Why

Keep the template in sync with validated improvements landing in downstream consumers so future syncs stay small.

## How

- Replace `PreloadMemoryTool` with the `load_memory` function tool in `agent.py` (simpler, no class instantiation)
- Add empty-password colon to `SESSION_SERVICE_URI` in `terraform/main/main.tf` (`user@` → `user:@`) for asyncpg URI parsing
- Drop stale `PydanticDeprecatedSince212` warning filter from `pyproject.toml` (no longer triggered)
- Assert logger name in `LoggingCallbacks` injection test

## Tests

- [x] `uv run ruff format && uv run ruff check --fix && uv run mypy && uv run pytest --cov` — all green, 100% coverage