### PR TITLE
chore: prepare release v0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5] - 2026-04-08
+
 ### Changed
 - Replace `PreloadMemoryTool` with the `load_memory` function tool in `agent.py` — memory is now retrieved on-demand when the LLM decides it is needed, rather than eager-preloaded into context on every turn (#150)
 - Add explicit empty-password colon to `SESSION_SERVICE_URI` in `terraform/main/main.tf` (`user@` → `user:@`) to align with the documented example in `docs/environment-variables.md` and self-document intentional empty password under IAM database auth (#150)
@@ -463,7 +465,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.12.4...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.12.5...HEAD
+[0.12.5]: https://github.com/doughayden/agent-foundation/compare/v0.12.4...v0.12.5
 [0.12.4]: https://github.com/doughayden/agent-foundation/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/doughayden/agent-foundation/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/doughayden/agent-foundation/compare/v0.12.1...v0.12.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.12.4"
+version = "0.12.5"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-04-02T19:58:22.589888Z"
+exclude-newer = "2026-04-03T20:08:26.717028Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -11,7 +11,7 @@ constraints = [{ name = "litellm", specifier = "<=1.82.6" }]
 
 [[package]]
 name = "agent-foundation"
-version = "0.12.4"
+version = "0.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Patch release v0.12.5 — latest kairos sync point for agent-foundation template consumers.

## Why

Backport a small batch of validated downstream fixes/enhancements from kairos so future template syncs stay small.

## How

- Bump version to 0.12.5 in `pyproject.toml` and `uv.lock`
- Convert `[Unreleased]` to `[0.12.5] - 2026-04-08` in `CHANGELOG.md`
- Update comparison links

## Release Notes

### Changed
- Replace `PreloadMemoryTool` with the `load_memory` function tool — memory is now retrieved on-demand when the LLM decides it is needed (#150)
- Add explicit empty-password colon to `SESSION_SERVICE_URI` in Terraform to align with documented example and self-document IAM DB auth intent (#150)
- Document memory read/write paths in AGENTS.md Architecture Overview (#150)

### Removed
- Stale `PydanticDeprecatedSince212` warning filter from `pyproject.toml` (#150)

## Tests

- [x] `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest --cov` — all green, 100% coverage
- [x] `uv lock` regenerated cleanly