### PR TITLE
feat: enhance OTel token and HTTP instrumentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ Source package lives under `src/` (single package — file references below use 
 - Security posture and pool config: `terraform/main/database.tf`, `docs/references/cloud-sql.md`, `docs/references/security-posture.md`
 - Scale path: bump instance tier first, then managed connection pooling (Enterprise Plus) when autoscaling demands it
 
+**asyncpg type strictness:** Direct SQL against the session DB must bind typed columns as native Python objects — asyncpg's codecs reject ISO strings for `timestamptz` (and other typed columns) with `DataError`. sqlite via aiosqlite tolerates strings, so sqlite-only tests miss the bug. Use `text(...).bindparams(bindparam("x", type_=DateTime(timezone=True)))` to force dialect-aware conversion.
+
 **Networking:** VPC with Private Services Access peering for Cloud SQL private IP.
 - Cloud Run uses direct VPC egress to reach Cloud SQL via Auth Proxy sidecar
 - Bastion host (e2-micro, COS, auto-updates) runs Auth Proxy for local developer access via IAP tunnel
@@ -131,6 +133,7 @@ uv run ruff format && uv run ruff check --fix && uv run mypy && uv run pytest --
 - Factory pattern (not context managers): `def _factory() -> MockType` returned by fixture
 - Environment mocking: `mocker.patch.dict(os.environ, env_dict)`
 - Test functions: Don't type hint custom fixtures, optional hints on built-ins for IDE
+- Naming: `Mock` prefix for test double classes (e.g., `MockState`); `mock_xxx` for instance fixtures; `create_mock_xxx` for factory fixtures returning `Callable`; no prefix for convenience fixtures returning real objects (e.g., `oauth_flow_config`); factory inner function named `_factory`
 
 **ADK Mocks:** Custom mocks mirror real ADK interfaces and live in `tests/conftest.py` (readonly contexts, callback contexts, tool contexts, LLM request/response shapes, etc.). For edge cases requiring custom internal structure, add a specific named fixture.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -111,6 +111,20 @@ OpenTelemetry resource attributes uniquely identify your service instances in tr
 
 `LoggingCallbacks` (in `callbacks.py`) logs agent lifecycle events (start/end, model calls, tool invocations) with automatic trace context correlation.
 
+### Custom Gen AI Usage Attributes
+
+`LoggingCallbacks.after_model` (registered as the root agent's `after_model_callback`) supplements the genai instrumentor's auto-emitted attributes with three token counts extracted from `GenerateContentResponseUsageMetadata`:
+
+| Attribute | Source field | Semconv status |
+|---|---|---|
+| `gen_ai.usage.cache_read.input_tokens` | `cached_content_token_count` | Canonical (Development stability) — matches "tokens served from provider-managed cache" |
+| `gen_ai.usage.reasoning_tokens` | `thoughts_token_count` | Draft / convention-consistent — name not yet final in semconv, but converging across Gemini / OpenAI / Anthropic telemetry |
+| `gen_ai.usage.tool_use.input_tokens` | `tool_use_prompt_token_count` | Custom — no semconv equivalent yet; name follows the `cache_read.input_tokens` pattern for symmetry |
+
+The genai instrumentor already auto-emits `gen_ai.usage.input_tokens` (from `prompt_token_count`) and `gen_ai.usage.output_tokens` (from `candidates_token_count`) on its `generate_content` span. The callback does not duplicate those. `total_token_count` is intentionally omitted — no corresponding semconv span attribute exists; the total is derivable as `input_tokens + output_tokens + reasoning_tokens + tool_use.input_tokens`.
+
+String literals are used at the emission site rather than imported constants because the installed `opentelemetry-semantic-conventions` (0.58b0) does not yet export constants for the cache/reasoning/tool-use attributes. On future version bumps, check `opentelemetry.semconv._incubating.attributes.gen_ai_attributes` and switch to constant imports once upstream ships them.
+
 ## Message Content Capture
 
 `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` controls LLM content capture:

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -9,6 +9,7 @@ Deep-dive technical documentation for optional follow-up.
 - [Deployment Modes](deployment.md) - Multi-environment strategy and infrastructure
 - [CI/CD Workflows](cicd.md) - Workflow architecture and mechanics
 - [Cloud SQL Scaling and Reliability](cloud-sql.md) - Instance tiers, backups, HA, connection pooling, monitoring
+- [Cloud Run Concurrency Tuning](cloud-run-concurrency-tuning.md) - Async runtime model, GIL, and sizing for single-process Cloud Run deployments
 
 ## Security
 

--- a/docs/references/cloud-run-concurrency-tuning.md
+++ b/docs/references/cloud-run-concurrency-tuning.md
@@ -1,0 +1,279 @@
+# Cloud Run Concurrency Tuning for Async Python Agents
+
+How to reason about `max_instance_request_concurrency`, instance sizing, and scaling for an ADK-based agent deployed as a single async uvicorn process on Cloud Run.
+
+This guide is generic — the runtime model, limits, and rationale apply to any self-hosted Python async agent on Cloud Run, not just this template.
+
+## Runtime Model
+
+The server entrypoint runs `uvicorn.run(app, ...)` with no `workers=` argument. That yields:
+
+- **One process** per container instance
+- **One asyncio event loop** inside that process
+- **No threads** doing request work (FastAPI handlers are `async def`)
+
+Every `await` in a handler yields control back to the event loop, letting other in-flight requests progress during I/O waits (LLM streams, DB queries, outbound HTTP). The loop is the sole request multiplexer — there is no thread pool or worker pool behind it.
+
+## What `max_instance_request_concurrency` Actually Bounds
+
+`max_instance_request_concurrency` on `google_cloud_run_v2_service.template` is the number of HTTP requests Cloud Run will route to a single instance *before spinning up a new instance*. It is not:
+
+- A thread count (no threads)
+- A worker count (no workers)
+- An OS-level concurrency primitive
+
+All it does is tell the Cloud Run load balancer when to fan out. That single async process absorbs every request routed to it.
+
+Once Cloud Run reaches `max_instance_count` instances *and* each is at `max_instance_request_concurrency`, additional requests queue. Queue depth shows up as latency.
+
+Reference: [Cloud Run — About container concurrency](https://docs.cloud.google.com/run/docs/about-concurrency).
+
+## Effective Concurrency Limits
+
+The event loop itself can juggle large numbers of concurrent awaits cheaply — [Piccolo's coroutine-scaling experiments](https://piccolo-orm.com/blog/what-is-the-maximum-number-of-coroutines-you-should-run-concurrently/) report asyncio comfortably running tens of thousands of coroutines, with external bottlenecks (rate limits, DB connection caps, network timeouts) binding long before the loop itself. What actually bounds safe per-instance concurrency:
+
+### 1. Memory per in-flight request
+
+Each concurrent request pins a stack of objects in memory for its duration. Order-of-magnitude contributions for a typical ADK agent:
+
+| Contributor | Typical size | Notes |
+|---|---|---|
+| Loaded session events | 100 KB – 5 MB | 20–100 events; bloats when past tool outputs (API responses, retrieved documents) are embedded in event content |
+| LLM response buffers | 5–50 KB | Streamed LLM response accumulates as it arrives; 500–10K tokens ≈ 2–40 KB text plus chunk overhead |
+| Tool output payloads | 10 KB – 10 MB | Highly variable; an API tool returning 1K records at ~500 B each ≈ 500 KB; JSON parse+validate transiently doubles |
+| Pydantic model graph | 1–5 MB | `Event` / `Content` / `Part` instances × hundreds per request; Python object overhead dominates |
+| OpenTelemetry spans | 50 KB – 1 MB | ~1 KB per span; 50–200 spans per complex request before export flushes |
+| Background task state | 1–5 MB | BG task builds its own event stream + clients while running (see §2) |
+| HTTP client buffers | ~100 KB | httpx pools, active TLS sessions per outbound call |
+
+Summed ranges:
+
+- **Light** (greeting, no tool calls): **2–5 MB**
+- **Medium** (1–2 tool calls with small results): **5–15 MB**
+- **Heavy** (bulk tool outputs, long sessions, many LLM turns): **20–50+ MB**
+
+> [!NOTE]
+> These are component estimates, not measurements. Before tuning based on them, measure actual resident set size (RSS) growth per in-flight request under realistic load — e.g., compare steady-state memory at low vs target concurrency, or expose a `/debug/memory` endpoint that reports `resource.getrusage(RUSAGE_SELF).ru_maxrss`. RSS is the process's non-swapped physical memory footprint, which is what Cloud Run compares against the `memory` limit.
+
+`memory / per_request_budget` is the hard ceiling. Exceed it and the instance OOMs.
+
+### 2. BackgroundTasks inflation
+
+If your agent spawns FastAPI `BackgroundTasks` or other post-response async work (streaming event delivery, webhook fan-out, cleanup), those keep running after the HTTP response returns. Cloud Run's `max_instance_request_concurrency` counts HTTP requests in-flight, not BG tasks — so it may route a new request while the previous one's BG task is still executing, holding memory. Agents with no post-response work have `D_bg = 0` and the multiplier below reduces to 1×; the rest of this section applies when `D_bg > 0`.
+
+Applying [Little's law](https://en.wikipedia.org/wiki/Little%27s_law) at steady state, with HTTP arrivals at rate R, HTTP handler duration `D_http`, and BG task duration `D_bg`:
+
+```
+in_flight_http  ≈ R × D_http        (capped by max_instance_request_concurrency)
+in_flight_bg    ≈ R × D_bg
+total_in_flight ≈ in_flight_http × (1 + D_bg/D_http)
+```
+
+The inflation multiplier is `1 + D_bg/D_http` and is workload-dependent:
+
+- **Single-turn** (handler returns after the only response event): `D_bg ≈ 0`, multiplier ~1×
+- **Multi-turn with streamed follow-up** (handler returns after first event; BG streams remaining LLM turns + tool calls): `D_bg` commonly equals or exceeds `D_http`, multiplier 2×–4×
+- **Tool-heavy agent flows** (many post-response LLM turns, bulk tool responses): multiplier can reach 5× or more
+
+Measure `D_bg` and `D_http` from your own traces rather than assuming a multiplier. Size memory budget for `max_instance_request_concurrency × (1 + D_bg/D_http) × per_request_MB`, not the HTTP cap alone.
+
+### 3. SQLAlchemy connection pool
+
+SQLAlchemy's async engine defaults to 5 connections + 10 overflow = 15 max per engine. Each engine has its own pool, so a deployment with multiple stores (e.g., session state plus any secondary store — OAuth contexts, job queues, audit logs) multiplies the per-instance connection count. Concurrency higher than pool size causes requests to wait for a connection to free.
+
+Tune pool size with `create_async_engine(uri, pool_size=N, max_overflow=M)` if concurrency justifies it.
+
+### 4. Cloud SQL (or other DB) connection cap
+
+The database tier sets a hard max-connection limit. Per-instance connection count has two regimes:
+
+- **Steady state** (`sum(pool_size) × instances`) — connections held open under typical concurrency. Fast operations (1–10 ms reads/writes) return to the pool quickly, so actual in-use count stays close to `pool_size × engines` most of the time.
+- **Peak with overflow** (`sum(pool_size + max_overflow) × instances`) — theoretical ceiling during bursts, slow queries, or pool warmup on new instances. Overflow connections open on demand when the base pool is saturated.
+
+Aggregate: `max_instances × connections_per_instance ≤ db_max_connections`, minus Postgres reservations (~3 for superuser/replication). On small tiers the formula can bind before memory or CPU — raising `max_instance_count` without matching DB headroom leads to intermittent connection failures under load (pool timeouts or driver-level rejections from the DB).
+
+## The GIL, Processes, and Parallelism
+
+Python's Global Interpreter Lock (GIL) lets only one thread execute Python bytecode at a time within a single process. Async coroutines on one event loop face the same limit — they parallelize only during I/O waits that release the GIL (socket reads, DB drivers with C extensions). Pure Python work (JSON parsing, pydantic validation, event shaping, prompt construction, card rendering) serializes on the one thread holding the GIL.
+
+Two ways to get real Python parallelism:
+
+1. **Multiple processes** (gunicorn/uvicorn workers, Agent Engine's managed runtime). Each process owns its own GIL. Cost: every process duplicates the app's in-memory state — runner, connection pools, observability exporters, plugin registries, loaded models.
+2. **C extensions that release the GIL** during compute (numpy, some DB drivers). Free when applicable.
+
+**The relevant question isn't "how many vCPUs do I have?" — it's "how much of each request is Python compute?"** For an I/O-dominant agent (time spent awaiting LLM / REST / DB), a single async process handles concurrency well regardless of vCPU count — the event loop multiplexes I/O waits and there's little Python compute to parallelize. Multi-process Python earns its keep only when both (a) you have multiple vCPUs *and* (b) per-request Python compute is significant enough that parallelizing it materially improves throughput.
+
+vCPU count is a cost/complexity dial, not a fixed baseline: smaller is cheaper and forces the single-process model; larger opens the door to multi-process if the compute mix justifies it. Start with the smallest size that fits your per-request memory footprint and scale up only when profiling shows Python compute is the bottleneck.
+
+## Why Agent Engine Uses 9 Processes and This Doesn't
+
+Vertex AI Agent Engine's [optimize-runtime documentation](https://docs.cloud.google.com/agent-builder/agent-engine/optimize-runtime) recommends `container_concurrency` as a multiple of 9 because their managed runtime bakes **9 agent processes per container**. Each process handles `container_concurrency / 9` in-flight requests. This is a gunicorn-worker model wrapping your agent inside their container.
+
+### vCPU is a rate limit, not a thread cap
+
+A Cloud Run `cpu = "N"` limit means "the container gets N vCPU-seconds per wall-clock second across all its threads and processes" — enforced by cgroups CPU quota. You can run more processes than vCPUs; they just time-share the budget. For an I/O-dominant workload, time-sharing is fine — most processes are parked on I/O waits at any instant, so oversubscription costs little.
+
+Agent Engine's 9 processes fit their container for the same reason a single async process fits many concurrent requests on one event loop: concurrency exceeds parallelism because work is I/O-bound.
+
+### The real constraints on adding processes
+
+Two reasons not to run multiple processes, applicable at any vCPU size:
+
+1. **Memory duplication.** Each Python process duplicates the full resident state — ADK runner, plugin registries, loaded module graph, SQLAlchemy pools, observability exporters, in-memory caches. Ballpark for a non-trivial agent: 150–300 MB per process. N processes costs roughly `N × 250 MB` in resident memory before per-request data lands. Agent Engine's containers must be sized to absorb 9× state; cost-tuned Cloud Run services usually aren't.
+
+2. **Parallelism gain depends on Python compute being significant.** Multi-process Python's headline benefit is GIL parallelism — N processes use N cores simultaneously for Python bytecode. That's only useful when (a) you provision ≥ N vCPUs *and* (b) per-request Python compute is a meaningful slice of wall-clock time. For I/O-dominant workloads, (b) rarely holds: the Python compute slice is thin, so parallelizing it yields modest throughput gains against a 2×–9× memory cost.
+
+At small vCPU counts there's also no parallelism to extract — only one instruction stream runs at a time regardless of process count. Multi-process there buys only *isolation* (one crashed process doesn't kill the others), which a single-purpose agent rarely values enough to pay for.
+
+### Choosing vCPU and process count together
+
+vCPU size and process count are a paired decision driven by the Python-compute share of each request:
+
+- **I/O-dominant** (e.g., ~95% awaiting LLM / REST / DB): one async process, smallest vCPU that fits per-request memory. Scaling goes horizontal via `max_instance_count`, not vertical.
+- **Mixed compute + I/O**: one async process per vCPU, sized to the compute share. Memory must absorb `N × app_state`. Consider DB tier implications — N× connection pools can exhaust a small DB.
+- **Python-compute dominant** (large prompt assembly, bulk validation, local inference, data transformation): multiple processes across multiple vCPUs is how you extract throughput. Memory + DB headroom are prerequisites.
+
+For I/O-dominant workloads specifically, the effective levers for latency and throughput are elsewhere: bigger DB tier, horizontal scaling via `max_instance_count`, keeping connection pools warm (see `cpu_idle` section), reducing LLM turns per user query. Provisioning more vCPU without a matching Python-compute bottleneck is mostly idle cores.
+
+If you migrate the agent to host inside Agent Engine, re-tune to their 9× model (e.g., `36`, `72`). That's their container architecture, not a universal rule.
+
+## Starting-Point Profile
+
+For an I/O-dominant async Python agent with modest traffic, as a cost-tuned starting point:
+
+| Setting | Value | Rationale |
+|---|---|---|
+| [`min_instance_count`](https://docs.cloud.google.com/run/docs/configuring/min-instances) | `1` | Avoids cold start on first request of the day |
+| [`max_instance_count`](https://docs.cloud.google.com/run/docs/configuring/max-instances-limits) | `10` | Bounds runaway cost for a single-tenant workload; plenty of headroom (project quota typically 1000) |
+| [`max_instance_request_concurrency`](https://docs.cloud.google.com/run/docs/about-concurrency) | `10` | Sized so `10 × (1 + D_bg/D_http) × per_request_MB` fits `memory` — see Effective Concurrency Limits for the math |
+| `cpu` | `"1"` | Cheap tier; matches a single async process naturally. Raise only if profiling shows Python compute bottleneck |
+| `memory` | `"2Gi"` | Starting budget; revisit with measured per-request MB and BG inflation multiplier |
+| [`cpu_idle`](https://docs.cloud.google.com/run/docs/configuring/cpu-allocation) | `true` | Request-based billing; idle instances cheap while keeping `min=1` warm |
+
+> [!NOTE]
+> These are starting points for a specific profile (I/O-dominant, cost-tuned, modest traffic). vCPU and memory are genuine tuning dials, not fixed assumptions — measure per-request memory and Python-compute share under realistic load, then adjust.
+
+## Example: Validating the Starting Point
+
+Applying the formulas from Effective Concurrency Limits against the Starting-Point Profile, for a Medium workload typical of a multi-tool agent (1–2 upstream API calls per user turn, streamed follow-up via background tasks):
+
+**Inputs:**
+
+- Per-request memory: Medium band midpoint ≈ **10 MB** (conversation's in-memory footprint during its active lifetime)
+- BG inflation: handler returns after the first response event; BG task streams follow-up events. `D_bg ≈ D_http` for light multi-turn → multiplier ≈ **2×**
+- Baseline resident memory: ≈ **300–500 MB** (ADK runner, plugins, SQLAlchemy engines, OTel exporters, Python interpreter — estimate, unmeasured)
+
+**Per-instance memory fit:**
+
+```
+in_flight_memory ≈ 10 × 2 × 10 MB = 200 MB
+total_rss        ≈ 400 MB baseline + 200 MB in-flight ≈ 600 MB of 2048 MB
+```
+
+Comfortable headroom. The model treats HTTP- and BG-phase in-flight items as separate 10 MB slots, which is slightly conservative — a conversation's HTTP and BG phases share the same loaded session + event list, so real memory is somewhat less.
+
+**Heavy-tail check:** per-request 40 MB × inflation 5× × concurrency 10 = 2000 MB for in-flight alone, approaching the 2 Gi ceiling. If traffic skews heavy, raise `memory` before `max_instance_request_concurrency`.
+
+**Event loop:** 10 HTTP + ~20 BG = 30 concurrent async tasks on one event loop. Three orders of magnitude below the coroutine counts asyncio handles routinely (see Effective Concurrency Limits intro) — no contention risk at this scale.
+
+**Horizontal-scale constraint — DB connections:**
+
+Two SQLAlchemy engines per instance (session service + OAuth store), each defaulting to `pool_size=5, max_overflow=10`. Two regimes:
+
+- **Steady state** — fast ops cycle connections back to the pool quickly, so actual in-use count per instance stays near `pool_size × engines ≈ 10` under typical concurrency. At `max_instance_count = 10` that aggregates to ~100 connections against a `db-custom-1-3840` tier with ~97 effective connections (after Postgres reservations for superuser/replication).
+- **Peak with overflow** — bursts, slow queries, or new-instance pool warmup can push per-instance count to `(pool_size + max_overflow) × engines ≈ 30`, reaching ~300 aggregate. At that point Cloud SQL rejects new connection attempts; failures surface to the app as SQLAlchemy connection errors (pool timeout when the local pool can't serve a request within `pool_timeout`, or a wrapped driver exception — e.g., `asyncpg.exceptions.TooManyConnectionsError` — when the DB itself refuses a new connection).
+
+Operational reality: at `max_instance_count = 10` we sit *at* the tier budget at steady peak (no wiggle room) and *blow past it* during any burst. Before pushing `max_instance_count` further, **bump the DB tier** — `db-custom-2-7680` supports ~200 connections, doubling burst headroom. See [Cloud SQL Scaling](cloud-sql.md). Reducing `max_overflow` per engine is an alternative that trades burst-connection rejection for burst latency (requests wait longer for pooled connections).
+
+**Conclusion:** the starting point holds for the Medium workload on a single instance — memory sits near 30% utilization and the event loop has ample headroom. Under horizontal scale, DB connections bind first, not memory or CPU. Measure per-request RSS and `D_bg` / `D_http` in production to confirm these estimates match reality before relying on them.
+
+## `cpu_idle` and First-Request Latency After Idle
+
+`min_instance_count = 1` eliminates cold start (container boot, app import, lifespan init) but does not guarantee the first request after an idle period will be fast. Two separate latency regimes exist:
+
+- **Cold start:** no instance exists. Container + app boot is the penalty.
+- **Warm-idle-to-active:** instance exists but hasn't served a request in a while. A different set of penalties apply.
+
+### What `cpu_idle = true` does
+
+With `cpu_idle = true` (request-based billing), the instance's CPU is throttled to <5% while no requests are in-flight, and unthrottled when a request arrives. Billing accrues only during request processing.
+
+With `cpu_idle = false` (instance-based billing), CPU is always fully allocated while the instance exists. Billing is continuous.
+
+References: [Cloud Run — CPU allocation](https://docs.cloud.google.com/run/docs/configuring/cpu-allocation), [Billing settings](https://docs.cloud.google.com/run/docs/configuring/billing-settings).
+
+### What's slow on first-after-idle
+
+1. **CPU unthrottle ramp** — small (~100 ms), real but usually not dominant
+2. **Stale connection pools** — the bigger penalty:
+   - Cloud SQL Auth Proxy ↔ Cloud SQL backend keepalive expires → first query re-handshakes TLS + auth
+   - httpx async clients to upstream APIs (LLM provider, external REST services) drop idle connections → new TLS handshake on first call
+   - SQLAlchemy pool recycles stale connections via `pool_pre_ping` or `pool_recycle`
+3. **ADC / IAM token refresh** — identity tokens refresh on a cadence; first request after idle may trigger one
+4. **Python GC and OS page cache** — long idle periods invite full GC cycles and page eviction; next request pays for reload
+5. **In-process caches** — any session-service or in-memory caches may have been GC'd
+
+Under throttled CPU, housekeeping that would overlap an idle period (keepalives, background tasks) runs slowly or not at all, so pools stay stale longer and re-establishment costs are paid in the request path.
+
+### Options
+
+| Option | Effect | Cost |
+|---|---|---|
+| `cpu_idle = false` | CPU always allocated; background housekeeping keeps pools and caches warm; first-after-idle request fast | ~2× instance cost (billed during idle too) |
+| Cloud Scheduler → `/health` every ~60s | Instance never sits idle long enough for pools to die; CPU briefly unthrottles each ping | Trivial (one scheduler job + ~1 request/min) |
+| Application-level keepalive task | Periodic async task pings DB/APIs to keep pools warm | Complexity; fights Cloud Run's stateless model |
+| Accept it | Simplest | Slow first-after-idle request |
+
+### Decision heuristics
+
+- **Dev or low-traffic** — `cpu_idle = true` is fine. First-after-idle slowness shows up but rarely matters.
+- **Low-traffic with latency SLOs** — Cloud Scheduler pinger is the best ROI: keeps pools warm without flipping the billing model.
+- **Steady prod traffic** — `cpu_idle = true` is fine; natural traffic keeps the instance active.
+- **Prod with unpredictable traffic + latency SLO** — `cpu_idle = false` is the clean answer; you're paying for `min=1` anyway, might as well keep it hot.
+
+The template defaults to `cpu_idle = true` because cost predictability matters more than sub-second first-request latency for most early-stage deployments. Revisit when an SLO makes the tradeoff concrete.
+
+Reference: [Cloud Run — General development tips](https://docs.cloud.google.com/run/docs/tips/general) (cold start and latency mitigation).
+
+## When to Scale Up vs Out vs Add Workers
+
+**Scale out (raise `max_instance_count`)** when:
+- Queue depth / tail latency grows under load
+- Memory per instance stays healthy
+- Cost per request is acceptable
+
+**Scale up memory (raise `memory`)** when:
+- Instances OOM before hitting concurrency cap
+- You want to raise per-instance concurrency without OOM risk
+- Pool sizes or cached state grow
+
+**Scale up CPU (raise `cpu`)** when:
+- Profiling shows CPU-bound time inside request handlers (not I/O waits)
+- Event loop tasks are observably starved
+- You plan to add uvicorn workers (below)
+
+**Add uvicorn workers** (only after raising CPU) when:
+- `cpu ≥ 2` and CPU profile shows GIL contention
+- Per-request Python compute is significant (heavy serialization, parsing, validation)
+- Memory can absorb `N × app_state` duplication
+
+**Raise `max_instance_request_concurrency`** when:
+- Instances are consistently underutilized (low CPU, low memory)
+- No queue depth, no tail latency issues
+- BackgroundTasks are light or absent
+
+## Observability Checklist
+
+Before tuning any of the above, confirm you can see:
+
+- Per-instance memory usage (Cloud Run container metrics)
+- Per-instance request count and queue depth
+- Event loop lag (custom metric if not provided by your observability stack)
+- DB connection pool saturation (SQLAlchemy pool status or DB-side connection count)
+- Request tail latency (p95, p99)
+
+Tune based on signal, not vibes.
+
+---
+
+← [Back to References](README.md) | [Documentation](../README.md)

--- a/docs/references/opentelemetry-architecture.md
+++ b/docs/references/opentelemetry-architecture.md
@@ -82,19 +82,7 @@ ADK's built-in tracing covers the agent orchestration layer:
 - Agent name, session ID, model, token usage, tool args/responses as span attributes
 - Gen AI semantic convention attributes (`gen_ai.operation.name`, `gen_ai.request.model`, etc.)
 
-ADK does **not** instrument HTTP routes. There are no `GET /health`, `POST /run`, or similar spans.
-
-### FastAPI Instrumentation (Not Included)
-
-`opentelemetry-instrumentation-fastapi` would add complementary HTTP-layer spans (not duplicates) as parent spans to ADK's `invocation` spans. This provides visibility into FastAPI routing, middleware, and response serialization latency. It is not included in the template but is useful for projects with custom routes.
-
-To add it:
-
-```python
-# In server.py, after get_fast_api_app() returns
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-FastAPIInstrumentor.instrument_app(app)
-```
+ADK does **not** instrument HTTP routes. There are no `GET /health`, `POST /run`, or similar spans. Projects that expose custom HTTP routes and want HTTP-layer spans can opt in — see [HTTP Layer Instrumentation (FastAPI)](#http-layer-instrumentation-fastapi) below.
 
 ## Dependency Management
 
@@ -106,6 +94,7 @@ FastAPIInstrumentor.instrument_app(app)
 | `opentelemetry-exporter-gcp-logging` | Cloud Logging export via `CloudLoggingExporter` |
 | `opentelemetry-instrumentation-logging` | Bridges Python `logging` module to OTel (injects trace context into `LogRecord` attributes) |
 | `opentelemetry-instrumentation-google-genai` | Genai SDK instrumentation. ADK's `[otel-gcp]` extra includes this, but the project maintains explicit version control |
+| `opentelemetry-instrumentation-fastapi` | Opt-in HTTP-layer instrumentation. Imported unconditionally; activation gated on `setup_opentelemetry(..., app=app)`. Pulls in `opentelemetry-instrumentation-asgi` + `opentelemetry-util-http` + `asgiref` transitively |
 
 ### Transitive Dependencies (via ADK)
 
@@ -145,17 +134,43 @@ async def my_background_fn(..., parent_otel_context=None):
             ...  # spans are linked to the parent trace
     finally:
         if token is not None:
-            with contextlib.suppress(ValueError):
-                otel_context.detach(token)
+            otel_context.detach(token)
 ```
 
-**Why suppress `ValueError` on detach:**
+Both `attach()` and `detach()` execute inside the background task's own async `contextvars.Context`. Because the token is created and released in the same context, no `ValueError` is raised and no defensive suppression is needed. This invariant is load-bearing: any refactor that moves `otel_context.attach(...)` outside the background task (e.g., back into the sync request handler) will introduce the "Token was created in a different Context" class of error.
 
-Python's [`ContextVar.reset()`](https://docs.python.org/3/library/contextvars.html#contextvars.ContextVar.reset) raises `ValueError` when the token was created in a different `contextvars.Context`. Starlette runs background tasks in a separate context copy, so the OTel token from `attach()` cannot be cleanly detached. This is a [known issue](https://github.com/open-telemetry/opentelemetry-python/issues/2606) in the OpenTelemetry Python SDK. The suppress is safe because:
+## HTTP Layer Instrumentation (FastAPI)
 
-- The `attach()` succeeded — spans are correctly linked to the parent trace
-- The background task is about to exit — no leaked context to clean up
-- OTel's own `detach()` implementation also catches all exceptions internally
+`opentelemetry-instrumentation-fastapi` is an optional, opt-in instrumentor that adds HTTP-layer spans as parents to ADK's `invocation` spans. Enable it by passing the FastAPI instance to `setup_opentelemetry(..., app=app)`; leave `app` as `None` to skip.
+
+A typical enabled trace tree looks like:
+
+```
+POST /some-route                     (FastAPI server span)
+├── POST /some-route http receive    (ASGI http.request event)
+├── <your custom handler spans>
+│   └── invocation                   (ADK)
+│       └── invoke_agent {agent}
+│           └── call_llm
+│               └── generate_content {model}
+├── POST /some-route http send       (ASGI http.response.start)
+└── POST /some-route http send       (ASGI http.response.body)
+```
+
+**Why `instrument_app(app)` instead of the global `.instrument()`:**
+
+`FastAPIInstrumentor` provides two APIs:
+
+| API | Effect |
+|---|---|
+| `FastAPIInstrumentor().instrument()` | Patches `FastAPI.__init__` so any FastAPI app **constructed after this call** gets auto-instrumented |
+| `FastAPIInstrumentor().instrument_app(app)` | Wraps middleware on the **existing** `app` instance |
+
+In `server.py`, the FastAPI app is created at module import time via `get_fast_api_app()`, well before `setup_opentelemetry()` is called inside `main()`. The global `.instrument()` form only patches future constructors, so it would miss the already-constructed app entirely. `instrument_app(app)` wraps the live instance and works regardless of construction order.
+
+**Two `http send` spans per request:**
+
+The ASGI instrumentor (to which `FastAPIInstrumentor` delegates) creates one span per outbound ASGI message. HTTP responses always produce two messages: `http.response.start` (status + headers) and `http.response.body` (body frame). Each span is tagged with an `asgi.event.type` attribute carrying the message type verbatim, so the two spans are distinguishable in Cloud Trace by inspecting that attribute. This is normal ASGI behavior, not a duplication bug. Source: `opentelemetry/instrumentation/asgi/__init__.py` (the `send_span.set_attribute("asgi.event.type", message["type"])` path).
 
 ---
 

--- a/docs/references/testing.md
+++ b/docs/references/testing.md
@@ -44,6 +44,27 @@ All reusable fixtures go in `tests/conftest.py`:
 
 ## Fixture Patterns
 
+### Test Double Naming
+
+Test double classes and fixtures follow a strict naming convention (established in root `conftest.py`):
+
+| Kind | Prefix | Example | Returns |
+|---|---|---|---|
+| Test double class | `Mock` | `MockState`, `MockOAuthContextStore` | — (defined in conftest) |
+| Instance fixture | `mock_` | `mock_state`, `mock_chat_client` | Single mock instance |
+| Factory fixture | `create_mock_` | `create_mock_state`, `create_mock_oauth_store` | `Callable` that builds instances |
+| Convenience fixture | (none) | `oauth_flow_config`, `valid_server_env` | Real objects / test data |
+
+Factory fixtures use `_factory` as their inner function name:
+
+```python
+@pytest.fixture
+def create_mock_state() -> Callable[..., MockState]:
+    def _factory(data: dict | None = None) -> MockState:
+        return MockState(data)
+    return _factory
+```
+
 ### Type Hints
 
 **Fixture definitions (strict in conftest.py):**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "google-cloud-logging>=3.12.1,<4.0.0",
     "opentelemetry-exporter-gcp-logging>=1.11.0a0,<2.0.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.37.0,<2.0.0",
+    "opentelemetry-instrumentation-fastapi>=0.58b0,<0.59",
     "opentelemetry-instrumentation-google-genai>=0.7b0,<0.8",
     "opentelemetry-instrumentation-logging>=0.58b0,<0.59",
     "pydantic>=2.11.0,<3.0.0",

--- a/src/agent_foundation/callbacks.py
+++ b/src/agent_foundation/callbacks.py
@@ -175,8 +175,9 @@ class LoggingCallbacks:
                 for key, value in {
                     "prompt_tokens": usage.prompt_token_count,
                     "response_tokens": usage.candidates_token_count,
-                    "total_tokens": usage.total_token_count,
                     "cached_tokens": usage.cached_content_token_count,
+                    "reasoning_tokens": usage.thoughts_token_count,
+                    "tool_use_tokens": usage.tool_use_prompt_token_count,
                 }.items()
                 if value is not None
             }
@@ -186,13 +187,18 @@ class LoggingCallbacks:
             span = trace.get_current_span()
             if usage.cached_content_token_count is not None:
                 span.set_attribute(
-                    "gen_ai.usage.experimental.cached_tokens",
+                    "gen_ai.usage.cache_read.input_tokens",
                     usage.cached_content_token_count,
                 )
-            if usage.total_token_count is not None:
+            if usage.thoughts_token_count is not None:
                 span.set_attribute(
-                    "gen_ai.usage.experimental.total_tokens",
-                    usage.total_token_count,
+                    "gen_ai.usage.reasoning_tokens",
+                    usage.thoughts_token_count,
+                )
+            if usage.tool_use_prompt_token_count is not None:
+                span.set_attribute(
+                    "gen_ai.usage.tool_use.input_tokens",
+                    usage.tool_use_prompt_token_count,
                 )
 
         return

--- a/src/agent_foundation/utils/observability.py
+++ b/src/agent_foundation/utils/observability.py
@@ -17,6 +17,7 @@ import warnings
 import google.auth
 import google.auth.transport.requests
 import grpc
+from fastapi import FastAPI
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.transport.grpc import AuthMetadataPlugin
 from google.cloud.logging_v2.services.logging_service_v2 import (
@@ -29,6 +30,7 @@ from opentelemetry.exporter.cloud_logging import CloudLoggingExporter
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
 )
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.google_genai import GoogleGenAiSdkInstrumentor
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.sdk._events import EventLoggerProvider
@@ -81,6 +83,7 @@ def setup_opentelemetry(
     project_id: str,
     agent_name: str,
     log_level: str,
+    app: FastAPI | None = None,
 ) -> None:
     """Set up complete OpenTelemetry observability with tracing and logging.
 
@@ -99,6 +102,9 @@ def setup_opentelemetry(
         project_id: GCP Project ID for trace and log export
         agent_name: Unique service identifier
         log_level: Logging verbosity level as string
+        app: Optional FastAPI instance. When provided, enables HTTP-layer
+            instrumentation (request/response spans as parents to ADK's
+            invocation spans). Leave as None to skip.
 
     Returns:
         None
@@ -154,12 +160,6 @@ def setup_opentelemetry(
     event_logger_provider = EventLoggerProvider(logger_provider)
     events.set_event_logger_provider(event_logger_provider)
 
-    # Inject OTel trace attributes in LogRecords
-    LoggingInstrumentor().instrument()
-
-    # ADK uses the Google Gen AI SDK
-    GoogleGenAiSdkInstrumentor().instrument()
-
     # Get the root logger and set the logging level
     root = logging.getLogger()
     root.setLevel(log_level)
@@ -195,5 +195,15 @@ def setup_opentelemetry(
         tracer_provider = TracerProvider()
         tracer_provider.add_span_processor(span_processor)
         trace.set_tracer_provider(tracer_provider)
+
+    # Inject OTel trace attributes in LogRecords
+    LoggingInstrumentor().instrument()
+
+    # ADK uses the Google Gen AI SDK
+    GoogleGenAiSdkInstrumentor().instrument()
+
+    if app is not None:
+        # instrument_app patches existing; .instrument() only patches future ones
+        FastAPIInstrumentor().instrument_app(app)
 
     return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,11 @@ def pytest_configure(config: pytest.Config) -> None:
     Therefore, unittest.mock is the ONLY tool available at this stage. This is
     the only place in the codebase where unittest.mock is used - all other mocking
     (fixtures and tests) uses pytest-mock's mocker fixture.
+
+    CONSEQUENCE: All src package imports in this file MUST be deferred to fixture
+    bodies or guarded by TYPE_CHECKING. A top-level ``from package.x import Y``
+    would execute during test collection — before these patches take effect —
+    possibly triggering real API calls.
     """
     from unittest.mock import Mock, patch
 
@@ -200,12 +205,16 @@ class MockUsageMetadata:
         candidates_token_count: int | None = None,
         total_token_count: int | None = None,
         cached_content_token_count: int | None = None,
+        thoughts_token_count: int | None = None,
+        tool_use_prompt_token_count: int | None = None,
     ) -> None:
         """Initialize mock usage metadata with optional token counts."""
         self.prompt_token_count = prompt_token_count
         self.candidates_token_count = candidates_token_count
         self.total_token_count = total_token_count
         self.cached_content_token_count = cached_content_token_count
+        self.thoughts_token_count = thoughts_token_count
+        self.tool_use_prompt_token_count = tool_use_prompt_token_count
 
 
 class MockLlmResponse:
@@ -436,6 +445,14 @@ def create_mock_usage_metadata() -> Callable[..., MockUsageMetadata]:
         return MockUsageMetadata(**kwargs)
 
     return _factory
+
+
+@pytest.fixture
+def mock_span(mocker: MockerFixture) -> MockType:
+    """Mock span returned by ``trace.get_current_span()`` in callbacks."""
+    span = mocker.Mock()
+    mocker.patch("agent_foundation.callbacks.trace.get_current_span", return_value=span)
+    return span
 
 
 @pytest.fixture

--- a/tests/test_logging_callbacks.py
+++ b/tests/test_logging_callbacks.py
@@ -228,8 +228,10 @@ class TestModelCallbacks:
         assert "Token usage:" in caplog.text
         assert "'prompt_tokens': 150" in caplog.text
         assert "'response_tokens': 50" in caplog.text
-        assert "'total_tokens': 200" in caplog.text
+        assert "total_tokens" not in caplog.text
         assert "cached_tokens" not in caplog.text
+        assert "reasoning_tokens" not in caplog.text
+        assert "tool_use_tokens" not in caplog.text
 
     def test_after_model_logs_cached_tokens_when_present(
         self,
@@ -277,6 +279,50 @@ class TestModelCallbacks:
 
         assert "'cached_tokens': 0" in caplog.text
 
+    def test_after_model_logs_reasoning_tokens_when_present(
+        self,
+        mock_logging_callback_context,
+        create_mock_llm_response,
+        create_mock_usage_metadata,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Verify after_model includes reasoning tokens when non-None."""
+        caplog.set_level(logging.INFO)
+        callbacks = LoggingCallbacks()
+
+        usage = create_mock_usage_metadata(
+            prompt_token_count=200,
+            candidates_token_count=50,
+            thoughts_token_count=75,
+        )
+        response = create_mock_llm_response(usage_metadata=usage)
+
+        callbacks.after_model(mock_logging_callback_context, response)
+
+        assert "'reasoning_tokens': 75" in caplog.text
+
+    def test_after_model_logs_tool_use_tokens_when_present(
+        self,
+        mock_logging_callback_context,
+        create_mock_llm_response,
+        create_mock_usage_metadata,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Verify after_model includes tool-use tokens when non-None."""
+        caplog.set_level(logging.INFO)
+        callbacks = LoggingCallbacks()
+
+        usage = create_mock_usage_metadata(
+            prompt_token_count=200,
+            candidates_token_count=50,
+            tool_use_prompt_token_count=30,
+        )
+        response = create_mock_llm_response(usage_metadata=usage)
+
+        callbacks.after_model(mock_logging_callback_context, response)
+
+        assert "'tool_use_tokens': 30" in caplog.text
+
     def test_after_model_skips_log_when_all_counts_none(
         self,
         mock_logging_callback_context,
@@ -311,37 +357,73 @@ class TestModelCallbacks:
 
         assert "Token usage:" not in caplog.text
 
-    def test_after_model_sets_span_attributes(
+    def test_after_model_sets_cache_read_input_tokens_attribute(
         self,
         mock_logging_callback_context,
         create_mock_llm_response,
         create_mock_usage_metadata,
-        mocker: MockerFixture,
+        mock_span,
     ) -> None:
-        """Verify after_model sets cached and total token span attributes."""
+        """Verify after_model sets the semconv cache_read.input_tokens attribute."""
         callbacks = LoggingCallbacks()
 
         usage = create_mock_usage_metadata(
             prompt_token_count=200,
             candidates_token_count=50,
-            total_token_count=250,
             cached_content_token_count=100,
         )
         response = create_mock_llm_response(usage_metadata=usage)
 
-        mock_span = mocker.Mock()
-        mocker.patch(
-            "agent_foundation.callbacks.trace.get_current_span",
-            return_value=mock_span,
+        callbacks.after_model(mock_logging_callback_context, response)
+
+        mock_span.set_attribute.assert_called_once_with(
+            "gen_ai.usage.cache_read.input_tokens", 100
         )
+
+    def test_after_model_sets_reasoning_tokens_attribute(
+        self,
+        mock_logging_callback_context,
+        create_mock_llm_response,
+        create_mock_usage_metadata,
+        mock_span,
+    ) -> None:
+        """Verify after_model maps thoughts_token_count to reasoning_tokens."""
+        callbacks = LoggingCallbacks()
+
+        usage = create_mock_usage_metadata(
+            prompt_token_count=200,
+            candidates_token_count=50,
+            thoughts_token_count=75,
+        )
+        response = create_mock_llm_response(usage_metadata=usage)
 
         callbacks.after_model(mock_logging_callback_context, response)
 
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.usage.experimental.cached_tokens", 100
+        mock_span.set_attribute.assert_called_once_with(
+            "gen_ai.usage.reasoning_tokens", 75
         )
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.usage.experimental.total_tokens", 250
+
+    def test_after_model_sets_tool_use_input_tokens_attribute(
+        self,
+        mock_logging_callback_context,
+        create_mock_llm_response,
+        create_mock_usage_metadata,
+        mock_span,
+    ) -> None:
+        """Verify after_model maps tool_use_prompt_token_count to tool_use input."""
+        callbacks = LoggingCallbacks()
+
+        usage = create_mock_usage_metadata(
+            prompt_token_count=200,
+            candidates_token_count=50,
+            tool_use_prompt_token_count=30,
+        )
+        response = create_mock_llm_response(usage_metadata=usage)
+
+        callbacks.after_model(mock_logging_callback_context, response)
+
+        mock_span.set_attribute.assert_called_once_with(
+            "gen_ai.usage.tool_use.input_tokens", 30
         )
 
     def test_after_model_skips_span_attributes_when_none(
@@ -349,7 +431,7 @@ class TestModelCallbacks:
         mock_logging_callback_context,
         create_mock_llm_response,
         create_mock_usage_metadata,
-        mocker: MockerFixture,
+        mock_span,
     ) -> None:
         """Verify after_model skips span attributes when counts are None."""
         callbacks = LoggingCallbacks()
@@ -359,12 +441,6 @@ class TestModelCallbacks:
             candidates_token_count=50,
         )
         response = create_mock_llm_response(usage_metadata=usage)
-
-        mock_span = mocker.Mock()
-        mocker.patch(
-            "agent_foundation.callbacks.trace.get_current_span",
-            return_value=mock_span,
-        )
 
         callbacks.after_model(mock_logging_callback_context, response)
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-04-03T20:08:26.717028Z"
+exclude-newer = "2026-04-16T18:08:04.423342Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -19,6 +19,7 @@ dependencies = [
     { name = "google-cloud-logging" },
     { name = "opentelemetry-exporter-gcp-logging" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-google-genai" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "pydantic" },
@@ -49,6 +50,7 @@ requires-dist = [
     { name = "google-cloud-logging", specifier = ">=3.12.1,<4.0.0" },
     { name = "opentelemetry-exporter-gcp-logging", specifier = ">=1.11.0a0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.37.0,<2.0.0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.58b0,<0.59" },
     { name = "opentelemetry-instrumentation-google-genai", specifier = ">=0.7b0,<0.8" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.58b0,<0.59" },
     { name = "pydantic", specifier = ">=2.11.0,<3.0.0" },
@@ -190,6 +192,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
 ]
 
 [[package]]
@@ -1832,6 +1843,38 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e2/03ff707d881d590c7adaed5e9d1979aed7e5e53fc1ed89035e5ed9f304af/opentelemetry_instrumentation_asgi-0.58b0.tar.gz", hash = "sha256:3ccc0c9c1c8c71e8d9da5945c6dcd9c0c8d147839f208536b7042c6dd98e65c9", size = 25116, upload-time = "2025-09-11T11:42:18.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/71/a00884c6655387c70070138acbf79a6616ad5d4489680f40708d75b598a7/opentelemetry_instrumentation_asgi-0.58b0-py3-none-any.whl", hash = "sha256:508a6d79e333d648d2afee0e140b6e80eb5d443be183be58e81d9ff88373168a", size = 16798, upload-time = "2025-09-11T11:41:08.105Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/09/4f8fcab834af6b403e5e2d94bdfb2d0835ba8cd1049bcc156995f47b65fb/opentelemetry_instrumentation_fastapi-0.58b0.tar.gz", hash = "sha256:03da470d694116a0a40f4e76319e42f3ff9efc49abf804b2acc2c07f96661497", size = 24598, upload-time = "2025-09-11T11:42:35.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/fb/82de06eba54e5cb979274f073065ebc374794853502d342b5155073d1194/opentelemetry_instrumentation_fastapi-0.58b0-py3-none-any.whl", hash = "sha256:d89bfec69c9ffc5d9f3fe58655d6660a66b2bca863b9132712c06edcde68b6fa", size = 13460, upload-time = "2025-09-11T11:41:28.507Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-google-genai"
 version = "0.7b0"
 source = { registry = "https://pypi.org/simple" }
@@ -1925,6 +1968,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/d8/4dd2fb622d26ec45b10ef63eb87fd512f5d7467c7bd35ce390629bd6dff8/opentelemetry_util_genai-0.3b0.tar.gz", hash = "sha256:83e127789a9ad615b8ca65f05fc36955a67ce257b06142bfd46159a3b7ed73d3", size = 31800, upload-time = "2026-02-20T16:16:14.807Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/e5/fada54909e445d7b4007f8b96221d571999efeab9446f3127cc1cebe5e07/opentelemetry_util_genai-0.3b0-py3-none-any.whl", hash = "sha256:ebc2b01bcb891ddc7218452470d189d3321cd742653299ff8e7de45debcfb986", size = 28426, upload-time = "2026-02-20T16:16:12.027Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/5f/02f31530faf50ef8a41ab34901c05cbbf8e9d76963ba2fb852b0b4065f4e/opentelemetry_util_http-0.58b0.tar.gz", hash = "sha256:de0154896c3472c6599311c83e0ecee856c4da1b17808d39fdc5cce5312e4d89", size = 9411, upload-time = "2025-09-11T11:43:05.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/a3/0a1430c42c6d34d8372a16c104e7408028f0c30270d8f3eb6cccf2e82934/opentelemetry_util_http-0.58b0-py3-none-any.whl", hash = "sha256:6c6b86762ed43025fbd593dc5f700ba0aa3e09711aedc36fd48a13b23d8cb1e7", size = 7652, upload-time = "2025-09-11T11:42:09.682Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Backport OTel enhancements from kairos: opt-in FastAPI HTTP-layer instrumentation, canonical `gen_ai.usage.*` semconv attributes for cached / reasoning / tool-use tokens, and a new Cloud Run concurrency tuning reference doc.

## Why

- The genai instrumentor already auto-emits `input_tokens` / `output_tokens`, but cached, reasoning (`thoughts_token_count`), and tool-use prompt tokens were either missing or recorded under non-canonical `gen_ai.usage.experimental.*` names. Aligning with OTel semconv (`cache_read.input_tokens`, `reasoning_tokens`, `tool_use.input_tokens`) makes dashboards portable and removes the `experimental.` prefix that signaled instability.
- `total_tokens` duplicated information derivable from the component counts and has no semconv equivalent — dropping it trims log noise and avoids publishing a non-standard span attribute.
- FastAPI HTTP-layer spans were previously undocumented-but-commented-out. Making it a first-class opt-in via `setup_opentelemetry(app=...)` lets downstream projects with custom routes add server spans without forking observability setup.
- The `ValueError` suppression on `otel_context.detach()` is unnecessary once `attach` and `detach` both run inside the background task's own context — replacing the suppression with an invariant comment clarifies intent.
- Cloud Run concurrency tuning is the most commonly-asked scaling question for downstream consumers; a reference doc captures the runtime model, memory math, GIL / process tradeoffs, and starting-point profile in one place.

## How

**Code**

- `utils/observability.py` — add optional `app: FastAPI | None = None` parameter; when provided, call `FastAPIInstrumentor().instrument_app(app)` after tracer provider setup; reorder instrumentors to run after tracer/logger provider registration
- `callbacks.py` — replace `total_tokens` / `experimental.cached_tokens` / `experimental.total_tokens` with canonical `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.reasoning_tokens`, `gen_ai.usage.tool_use.input_tokens`; update log dict keys to match (`cached_tokens`, `reasoning_tokens`, `tool_use_tokens`)
- `pyproject.toml` / `uv.lock` — add `opentelemetry-instrumentation-fastapi>=0.58b0,<0.59`

**Tests**

- `conftest.py` — expand `MockUsageMetadata` with `thoughts_token_count` / `tool_use_prompt_token_count`; add `mock_span` fixture that patches `trace.get_current_span`
- `test_logging_callbacks.py` — add log + span assertions for the two new attributes; refactor existing span test to use `mock_span`; update negative assertions for the removed `total_tokens` key

**Docs**

- `docs/observability.md` — new "Custom Gen AI Usage Attributes" table
- `docs/references/opentelemetry-architecture.md` — rework FastAPI section (opt-in activation, `instrument_app` vs `.instrument()` rationale, dual `http send` span note); drop stale `ValueError` suppression rationale
- `docs/references/cloud-run-concurrency-tuning.md` — new deep-dive; linked from `docs/references/README.md`
- `docs/references/testing.md` — add "Test Double Naming" table
- `AGENTS.md` — asyncpg type strictness note; test-double naming convention

## Breaking Changes

- `LoggingCallbacks.after_model` span attributes renamed:
  - `gen_ai.usage.experimental.cached_tokens` → `gen_ai.usage.cache_read.input_tokens`
  - `gen_ai.usage.experimental.total_tokens` → **removed** (derive as `input_tokens + output_tokens + reasoning_tokens + tool_use.input_tokens`)
- Log entry key `total_tokens` removed from the `Token usage:` log line.
- Dashboards or alert rules referencing the `experimental.*` names must be updated before merge rolls to prod.

## Tests

- [ ] `uv run ruff format && uv run ruff check --fix && uv run mypy && uv run pytest --cov` passes locally
- [ ] New unit tests in `test_logging_callbacks.py` cover log output and span attributes for cached / reasoning / tool-use tokens
- [ ] `mock_span` fixture consumed by refactored span assertion tests — no regressions in negative-path test (`test_after_model_skips_span_attributes_when_none`)
- [ ] Manual: deploy locally via `docker compose up --build --watch`, exercise an agent flow that emits `thoughts_token_count` / `tool_use_prompt_token_count`, inspect Cloud Trace for the three new span attributes
- [ ] Manual: call `setup_opentelemetry(..., app=app)` from `server.py` (or a dev harness) and confirm `POST /run` FastAPI server spans appear as parents of ADK `invocation` spans
- [ ] Docs render correctly on GitHub (tables, callouts, internal links in `cloud-run-concurrency-tuning.md`)