### PR TITLE
chore: prepare release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-21
+
+### Added
+- Opt-in FastAPI HTTP-layer instrumentation via `setup_opentelemetry(app=...)` — emits server spans as parents to ADK `invocation` spans; disabled by default (#153)
+- `gen_ai.usage.reasoning_tokens` span attribute and `reasoning_tokens` log entry, sourced from Gemini's `thoughts_token_count` (#153)
+- `gen_ai.usage.tool_use.input_tokens` span attribute and `tool_use_tokens` log entry, sourced from `tool_use_prompt_token_count` (#153)
+- Cloud Run Concurrency Tuning reference doc — runtime model, memory math, GIL / multi-process tradeoffs, and starting-point profile for async Python agents (#153)
+- Test Double Naming convention in testing reference (`Mock` / `mock_` / `create_mock_` prefixes) and AGENTS.md (#153)
+- `asyncpg` type strictness note in AGENTS.md (bind typed columns as native Python objects, not ISO strings) (#153)
+- Session state security posture section in security reference — encryption at rest, user isolation, value-safe logging, ADK OAuth2 credential refresher (#152)
+
+### Changed
+- **BREAKING:** Rename `gen_ai.usage.experimental.cached_tokens` span attribute to canonical `gen_ai.usage.cache_read.input_tokens` per OTel semantic conventions — update any dashboards or alerts keyed on the old name (#153)
+- Upgrade `google-adk` pin `1.28.0` → `1.30.0` (#154)
+- Filter ADK `PLUGGABLE_AUTH` experimental `UserWarning` by source module in `[tool.pytest.ini_options]` (#154)
+
+### Removed
+- **BREAKING:** `total_tokens` entry from `after_model` token usage log line and `gen_ai.usage.experimental.total_tokens` span attribute — derive from component counts instead (no semconv equivalent exists); update any dashboards or alerts that referenced the old attribute (#153)
+
 ## [0.12.5] - 2026-04-08
 
 ### Changed
@@ -465,7 +484,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.12.5...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/doughayden/agent-foundation/compare/v0.12.5...v0.13.0
 [0.12.5]: https://github.com/doughayden/agent-foundation/compare/v0.12.4...v0.12.5
 [0.12.4]: https://github.com/doughayden/agent-foundation/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/doughayden/agent-foundation/compare/v0.12.2...v0.12.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.12.5"
+version = "0.13.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-04-16T19:40:32.228849Z"
+exclude-newer = "2026-04-16T20:38:08.794542Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -11,7 +11,7 @@ constraints = [{ name = "litellm", specifier = "<=1.82.6" }]
 
 [[package]]
 name = "agent-foundation"
-version = "0.12.5"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Release v0.13.0 — minor bump covering three merged PRs since v0.12.5.

## Why

SemVer pre-1.0 MINOR bump because this cycle introduces both new features (opt-in FastAPI instrumentation, additional `gen_ai.usage.*` attributes, Cloud Run concurrency reference doc) and breaking changes to observability span attributes (experimental names renamed/removed).

## How

- Bump `pyproject.toml` version `0.12.5` → `0.13.0`
- Refresh `uv.lock`
- Finalize `CHANGELOG.md` `[0.13.0] - 2026-04-21` section with categorized entries; explicit `BREAKING:` prefix on the two span-attribute changes
- Update comparison links at bottom of CHANGELOG

## Release Contents

- #152 — docs: document OAuth state security posture
- #153 — feat: enhance OTel token and HTTP instrumentation (BREAKING: span attribute renames)
- #154 — chore: upgrade google-adk to 1.30.0

## Breaking Changes

Consumers with dashboards or alerts keyed on these OTel span attributes must update before deploying v0.13.0:

- `gen_ai.usage.experimental.cached_tokens` → `gen_ai.usage.cache_read.input_tokens` (renamed to canonical semconv)
- `gen_ai.usage.experimental.total_tokens` → **removed** (derive as `input_tokens + output_tokens + reasoning_tokens + tool_use.input_tokens`)
- `total_tokens` entry also removed from the `after_model` token usage log line

## Tests

- [ ] `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest --cov` passes on this branch
- [ ] CHANGELOG renders correctly on GitHub (no broken comparison links)
- [ ] After merge: tag `v0.13.0` pushed and visible on the Releases page