### PR TITLE
refactor(terraform)!: rename main module outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **BREAKING:** Required status check renamed from `Required Checks / required-status` to `CI / status`. Consumers with branch protection configured must update the required check name (see `docs/references/protection-strategies.md` Prerequisites for the migration path)
+- **BREAKING:** Rename `terraform/main` outputs for consistent `app_*` / `bastion_*` prefixes:
+  `deployed_image` → `app_deployed_image`, `service_account_email` → `app_service_account_email`,
+  `service_account_roles` → `app_service_account_roles`, `cloud_run_services` → `app_cloud_run_services`,
+  `configured_environment_variables` → `app_environment_variables`
+- `app_environment_variables` now reflects the deployed Cloud Run service env, not the configured input
 - Consolidated `code-quality.yml` and `required-checks.yml` into a single self-contained `ci.yml` workflow with three jobs (`changes`, `code-quality`, `status`)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `service_account_roles` → `app_service_account_roles`, `cloud_run_services` → `app_cloud_run_services`,
   `configured_environment_variables` → `app_environment_variables`
 - `app_environment_variables` now reflects the deployed Cloud Run service env, not the configured input
+- **BREAKING:** Replace `uri` (string) with `urls` (list) in `app_cloud_run_services.<location>` to surface all
+  configured service URLs (deterministic and random) for auditability
 - Consolidated `code-quality.yml` and `required-checks.yml` into a single self-contained `ci.yml` workflow with three jobs (`changes`, `code-quality`, `status`)
 
 ### Removed

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -73,7 +73,7 @@ locals {
   }
 
   # Recycle docker_image from previous deployment if not provided
-  docker_image = coalesce(var.docker_image, try(data.terraform_remote_state.main.outputs.deployed_image, null))
+  docker_image = coalesce(var.docker_image, try(data.terraform_remote_state.main.outputs.app_deployed_image, null))
 }
 
 resource "google_service_account" "app" {

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -201,3 +201,15 @@ data "google_cloud_run_v2_service" "app" {
   name     = google_cloud_run_v2_service.app[each.key].name
   location = each.key
 }
+
+# Unpack deployed Cloud Run service environment variables for Terraform output
+locals {
+  # Select any deployed service — they share env config across regions
+  app_service_any = values(data.google_cloud_run_v2_service.app)[0]
+
+  # Filter out sidecars by matching the deployed app image
+  app_container_any = one([for c in local.app_service_any.template[0].containers : c if c.image == local.docker_image])
+
+  # Project container env objects to a key, value map (secret env values display as empty strings)
+  app_environment_variables = { for e in local.app_container_any.env : e.name => e.value }
+}

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -210,6 +210,6 @@ locals {
   # Filter out sidecars by matching the deployed app image
   app_container_any = one([for c in local.app_service_any.template[0].containers : c if c.image == local.docker_image])
 
-  # Project container env objects to a key, value map (secret env values display as empty strings)
+  # Project the container env objects to a key, value map (secret env values display as empty strings)
   app_environment_variables = { for e in local.app_container_any.env : e.name => e.value }
 }

--- a/terraform/main/outputs.tf
+++ b/terraform/main/outputs.tf
@@ -84,22 +84,14 @@ output "app_cloud_run_services" {
     loc => {
       latest_ready_revision = split("revisions/", svc.latest_ready_revision)[1]
       update_time           = svc.update_time
-      uri                   = svc.uri
+      urls                  = svc.urls
     }
   }
 }
 
-locals {
-  # Select any deployed service — they share env config across regions
-  app_service_any = values(data.google_cloud_run_v2_service.app)[0]
-
-  # Filter out sidecars by matching the deployed app image
-  app_container_any = one([for c in local.app_service_any.template[0].containers : c if c.image == local.docker_image])
-}
-
 output "app_environment_variables" {
-  description = "Deployed Agent app Cloud Run service environment variables"
-  value       = { for item in local.app_container_any.env : item.name => item.value }
+  description = "Agent app Cloud Run service environment variables"
+  value       = local.app_environment_variables
 }
 
 output "workload_identity_pool_principal_identifier" {

--- a/terraform/main/outputs.tf
+++ b/terraform/main/outputs.tf
@@ -23,17 +23,17 @@ output "terraform_state_bucket" {
   value       = var.terraform_state_bucket
 }
 
-output "deployed_image" {
-  description = "Deployed Docker image URI"
+output "app_deployed_image" {
+  description = "Deployed Agent app Docker image URI"
   value       = local.docker_image
 }
 
-output "service_account_email" {
+output "app_service_account_email" {
   description = "Agent app service account email"
   value       = google_service_account.app.email
 }
 
-output "service_account_roles" {
+output "app_service_account_roles" {
   description = "Agent app service account project IAM roles"
   value       = local.app_iam_roles
 }
@@ -78,7 +78,7 @@ output "bastion_service_account_roles" {
   value       = local.bastion_iam_roles
 }
 
-output "cloud_run_services" {
+output "app_cloud_run_services" {
   description = "Agent app Cloud Run service details per location"
   value = { for loc, svc in data.google_cloud_run_v2_service.app :
     loc => {
@@ -89,9 +89,17 @@ output "cloud_run_services" {
   }
 }
 
-output "configured_environment_variables" {
-  description = "Configured Cloud Run service environment variables"
-  value       = local.run_app_env
+locals {
+  # Select any deployed service — they share env config across regions
+  app_service_any = values(data.google_cloud_run_v2_service.app)[0]
+
+  # Filter out sidecars by matching the deployed app image
+  app_container_any = one([for c in local.app_service_any.template[0].containers : c if c.image == local.docker_image])
+}
+
+output "app_environment_variables" {
+  description = "Deployed Agent app Cloud Run service environment variables"
+  value       = { for item in local.app_container_any.env : item.name => item.value }
 }
 
 output "workload_identity_pool_principal_identifier" {


### PR DESCRIPTION
## What

Rename `terraform/main` outputs for consistent `app_*` / `bastion_*` prefixes, and shift `app_environment_variables` to surface deployed Cloud Run state instead of the configured input.

## Why

Outputs scoped to a runtime principal now share a prefix (`app_*` for the Cloud Run app, `bastion_*` for the bastion host). Infra and config outputs (project, region, cloud_sql_*, session_service_uri, WIF) stay unprefixed. The grouping reads cleanly and matches how the resources are actually structured.

The semantic change to `app_environment_variables` reflects what is actually live, which is more useful for diagnosing config drift than echoing back the input.

## How

- Rename five outputs: `deployed_image`, `service_account_email`, `service_account_roles`, `cloud_run_services`, `configured_environment_variables` → `app_deployed_image`, `app_service_account_email`, `app_service_account_roles`, `app_cloud_run_services`, `app_environment_variables`
- Source `app_environment_variables` from `data.google_cloud_run_v2_service.app`, filtering containers by image match to skip the Cloud SQL Auth Proxy sidecar
- Add output-scoped locals (`app_service_any`, `app_container_any`) for readability of the compound expression
- Update `main.tf` recycle path: `data.terraform_remote_state.main.outputs.deployed_image` → `app_deployed_image`
- Add CHANGELOG entries under `[Unreleased]` documenting the rename mapping and the semantic shift

## Post-opening edits

- Relocate the `app_environment_variables` locals from `outputs.tf` into `main.tf` alongside the existing app locals, and reuse them via a new `local.app_environment_variables` projection
- Replace `uri` (string) with `urls` (list) in `app_cloud_run_services.<location>` to surface all configured service URLs (deterministic and random) for auditability. Additional BREAKING bullet added to CHANGELOG
- Drop the "Deployed" qualifier from the `app_environment_variables` description for consistency with the rest of the `app_*` description set (deployed semantic is documented in the `main.tf` heading comment near the locals)

## Tests

- [x] `terraform plan` succeeds against existing dev state with renamed outputs
- [x] Plan diff shows old outputs being destroyed and new outputs added cleanly
- [x] `values(data.google_cloud_run_v2_service.app)[0]` resolves without indexing errors
- [x] `one()` filter selects exactly the app container, excluding the Cloud SQL proxy sidecar
- [ ] First apply after merge succeeds with `var.docker_image` provided

## Breaking Changes

Five terraform output names changed, and `app_cloud_run_services.<location>.uri` (string) was replaced with `urls` (list). Consumer scripts running `terraform output <name>` or reading the URL field need to use the new names and shape. The CHANGELOG documents the full mapping.

First apply after merge requires `var.docker_image` to be set. The recycle path in `main.tf` uses `try(...app_deployed_image, null)`, and the renamed output is not yet in remote state, so the fallback resolves to null. CI always passes the image, so this only matters for local apply.