### PR TITLE
fix: replace instanceAdmin.v1 with compute.admin

### DIFF
--- a/terraform/bootstrap/module/gcp/main.tf
+++ b/terraform/bootstrap/module/gcp/main.tf
@@ -19,6 +19,7 @@ locals {
     "roles/artifactregistry.writer",
     "roles/cloudsql.admin",
     "roles/compute.instanceAdmin.v1",
+    "roles/compute.networkAdmin", # Required for google_compute_network creation in main module
     "roles/iam.serviceAccountAdmin",
     "roles/iam.serviceAccountUser", # Required for Cloud Run to attach service accounts during deployment
     "roles/resourcemanager.projectIamAdmin",

--- a/terraform/bootstrap/module/gcp/main.tf
+++ b/terraform/bootstrap/module/gcp/main.tf
@@ -18,8 +18,7 @@ locals {
     "roles/aiplatform.user",
     "roles/artifactregistry.writer",
     "roles/cloudsql.admin",
-    "roles/compute.instanceAdmin.v1",
-    "roles/compute.networkAdmin", # Required for google_compute_network creation in main module
+    "roles/compute.admin",
     "roles/iam.serviceAccountAdmin",
     "roles/iam.serviceAccountUser", # Required for Cloud Run to attach service accounts during deployment
     "roles/resourcemanager.projectIamAdmin",


### PR DESCRIPTION
## What

Add `roles/compute.networdmin` to the `github_workload_iam_roles` set in `terraform/bootstrap/module/gcp/main.tf`.

## Why

First-time deployment fails with a 403 when Terraform attempts to create the VPC network in `terraform/main/network.tf`. The bootstrap currently grants `roles/compute.instanceAdmin.v1` but not `roles/compute.networkAdmin`, which is required for `compute.networks.create`.

Every new user following the getting-started guide hits this failure on their first merge-to-main and must manually grant the role out-of-band to unblock.

## How

- Add `"roles/compute.networkAdmin"` to `github_workload_iam_roles` in `terraform/bootstrap/module/gcp/main.tf`
- No changes to `terraform/main/network.tf` are needed — the role is granted at bootstrap time, so IAM propagation has already occurred before CI/CD runs the main module

## Scope Change
- Replace instanceAdmin.v1 with compute.admin in bootstrap
- Grants permission to the WIF principal to create networks and firewall rules in main module

## Tests

- [x] Verified against existing bootstrap module structure — role is applied via `google_project_iam_member.github` which iterates `github_workload_iam_roles`
- [x] Confirmed `roles/compute.networkAdmin` covers `compute.networks.create` (required permission for `google_compute_network`)
- [x] No `time_sleep` propagation guard needed in `network.tf` — bootstrap is a one-time manual step that runs well before the first CI/CD apply

## Related Issues

Closes #166