### PR TITLE
docs: document pre-commit install and usage

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -77,6 +77,7 @@ docker compose up --build --watch  # Standard (cloud resources, mirrors producti
 # Or: uv run server                # Local-only with cloud resource URIs commented out in .env
 
 # Quality checks before commit (100% coverage required)
+# Pre-commit automates format/lint/typecheck if installed
 uv run ruff format && uv run ruff check && uv run mypy
 uv run pytest --cov --cov-report=term-missing
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,6 +104,26 @@ Run format, lint, type check, and unit tests (100% coverage required) **before e
 - **Docstrings:** Google-style format (args, returns, exceptions)
 - **Testing:** 100% coverage on production code, exclusions for configuration modules, fixtures in `conftest.py`, test behaviors and errors
 
+### Pre-commit Hooks
+
+Pre-commit runs format, lint, and type checks as a fix-in-place git hook on every `git commit`. It does not run pytest, so coverage validation still requires `uv run pytest --cov`.
+
+**One-time setup** (writes `.git/hooks/pre-commit`):
+
+```bash
+uv run pre-commit install
+```
+
+**Manual invocation:**
+
+```bash
+uv run pre-commit run --all-files              # All hooks on all tracked files
+uv run pre-commit run --files path/to/file     # Scope to specific files
+uv run pre-commit run ruff-format              # Run a single hook
+```
+
+Hooks are configured in `.pre-commit-config.yaml`. Versions for the `language: system` hooks (ruff, mypy) are pinned in `uv.lock`. `pre-commit autoupdate` is a no-op for these hooks; update versions with `uv lock --upgrade` instead.
+
 See [Testing Strategy](references/testing.md) and [Code Quality](references/code-quality.md) references for detailed patterns, tool usage, and exclusion strategies.
 
 ## Docker Compose for Standard Development


### PR DESCRIPTION
## What

Add a `### Pre-commit Hooks` subsection to `docs/development.md` covering install and manual invocation.

## Why

PR #168 introduced local pre-commit hooks but did not document how to install or use them. Developers had no user-facing instructions for wiring the git hook or running hooks manually. The `AGENTS.md` mention targets AI agents (the `autoupdate` no-op directive) rather than human developers.

## How

- New `### Pre-commit Hooks` subsection nested under `## Code Quality & Testing`
- Documents one-time install via `uv run pre-commit install`
- Covers manual invocation patterns (`--all-files`, `--files <path>`, single-hook by name)
- Notes that hooks intentionally skip pytest, so coverage validation still requires explicit `uv run pytest --cov`
- Restates the autoupdate caveat for `language: system` hooks (versions pinned in `uv.lock`, update via `uv lock --upgrade`)

## Tests

- [x] Ran `uv run pre-commit run --files docs/development.md` and confirmed all applicable hooks pass (trailing-whitespace, end-of-file-fixer); Python and config-file hooks correctly skip on a markdown-only diff
- [x] Confirmed `docs/development.md` length stays within the project's ~300-line budget (281 lines after edit, was 261)
- [x] Reviewed the rendered section in context to confirm heading hierarchy matches the existing pattern (`###` subsections under `##` sections, like `### Dependencies` under `## Common Tasks`) and the new content slots cleanly between the Standards bullets and the references link