### PR TITLE
chore: prepare release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-13
+
 ### Added
 - Optional `image_name` and `context` overrides on `.github/workflows/docker-build.yml` to support building subproject images alongside the primary app
 - Optional `image_name` override on `.github/workflows/pull-and-promote.yml` (applies to both source and target by design — image name stays static across environments)
@@ -14,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Subproject Builds section in `docs/references/cicd.md` covering the override pattern, the per-context `.dockerignore` gotcha, the per-subproject CI lane recipe, and the rationale for not exposing a `registry` override
 - Consumer Extension Points entries in `AGENTS.md` for adding a CI lane and adding a subproject Docker image to the deploy pipeline
 - Migration bullet in `docs/references/protection-strategies.md` Prerequisites for renamed required-status checks (do the swap on the PR before merging to avoid an unprotected window)
+- Local `pre-commit` hooks via `.pre-commit-config.yaml` covering trailing whitespace, end-of-file, YAML, TOML, large-file checks, `uv-lock` sync, and `language: system` hooks for ruff format, ruff check, and mypy (#168)
+- Pre-commit Hooks subsection in `docs/development.md` covering install, manual invocation patterns, and the `language: system` autoupdate caveat (#170)
+- Consumer Extension Points row in `AGENTS.md` pointing at ADK model selection for swapping the LLM (Gemini string, Model Garden endpoint, LiteLlm/MaaS connectors) (#143)
 
 ### Changed
 - **BREAKING:** Required status check renamed from `Required Checks / required-status` to `CI / status`. Consumers with branch protection configured must update the required check name (see `docs/references/protection-strategies.md` Prerequisites for the migration path)
@@ -25,11 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Replace `uri` (string) with `urls` (list) in `app_cloud_run_services.<location>` to surface all
   configured service URLs (deterministic and random) for auditability
 - Consolidated `code-quality.yml` and `required-checks.yml` into a single self-contained `ci.yml` workflow with three jobs (`changes`, `code-quality`, `status`)
+- Use the official Claude GitHub Action app for PR automation; remove explicit GitHub token from job step inputs (#156)
+- Upgrade `google-adk` pin `1.30.0` → `1.33.0` (#171)
 
 ### Removed
 - `.github/workflows/code-quality.yml` (consolidated into `ci.yml`)
 - `.github/workflows/required-checks.yml` (consolidated into `ci.yml`)
 - `workflow_dispatch` and `workflow_call` triggers from the code-quality pipeline (intentional — neither was invoked, and `ci.yml` is now self-contained)
+
+### Fixed
+- Replace `instanceAdmin.v1` with `compute.admin` in bootstrap WIF roles to unblock first-time VPC creation (#167)
 
 ## [0.13.0] - 2026-04-21
 
@@ -508,7 +518,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/doughayden/agent-foundation/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/doughayden/agent-foundation/compare/v0.12.5...v0.13.0
 [0.12.5]: https://github.com/doughayden/agent-foundation/compare/v0.12.4...v0.12.5
 [0.12.4]: https://github.com/doughayden/agent-foundation/compare/v0.12.3...v0.12.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.13.0"
+version = "0.14.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-05-08T21:16:53.715479Z"
+exclude-newer = "2026-05-08T22:15:31.043448Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -11,7 +11,7 @@ constraints = [{ name = "litellm", specifier = "<=1.82.6" }]
 
 [[package]]
 name = "agent-foundation"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Cut v0.14.0 (minor bump) from main: bump version, dated CHANGELOG section, and the comparison links.

## Why

Nine commits have landed since v0.13.0, including one breaking refactor (`refactor(terraform)!`), three features, and a fix. Pre-1.0 semver puts breaking changes plus new features in MINOR. Time to ship.

## How

- Bump `pyproject.toml` version `0.13.0` → `0.14.0` and regenerate `uv.lock`
- Add the six missing CHANGELOG entries (#143, #156, #167, #168, #170, #171) to `[Unreleased]` and add a Fixed category for the VPC creation 403 fix (#167)
- Skip #169 from CHANGELOG (whitespace cleanup, not user-visible)
- Convert `[Unreleased]` heading to `## [0.14.0] - 2026-05-13` and add a new empty `[Unreleased]` above
- Update comparison links: `[Unreleased]: ...v0.14.0...HEAD`, add `[0.14.0]: ...v0.13.0...v0.14.0`

## Tests

- [x] Full local quality gate passes: `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest --cov`
- [x] 100% coverage maintained (74 tests, 188 statements, 38 branches)
- [x] Pre-commit `uv-lock` hook on commit confirms `pyproject.toml` and `uv.lock` are in sync
- [x] CHANGELOG audit: verified each commit since v0.13.0 against `[Unreleased]` entries; nothing missing apart from the six entries added in this PR
- [x] Comparison link remote verified via `git remote -v` (`origin` points at `doughayden/agent-foundation`)
- [ ] CI green (verified after push)