### PR TITLE
docs: clarify mypy scope and test typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ uv run ruff format && uv run ruff check --fix && uv run mypy && uv run pytest --
 - If future imports trigger env var reads at collection time, use direct `os.environ["KEY"] = "value"` (never `setdefault()`)
 
 **Fixtures:**
-- Type hints: `MockerFixture` → `MockType` return (CONVENTION ONLY — mypy is scoped to `src/`; conftest typing is enforced by reviewers, see `docs/references/code-quality.md` Test Suite Typing Strategy)
+- Type hints: `MockerFixture` → `MockType` return (CONVENTION ONLY — see `docs/references/code-quality.md` Test Suite Typing Strategy)
 - Factory pattern (not context managers): `def _factory() -> MockType` returned by fixture
 - Environment mocking: `mocker.patch.dict(os.environ, env_dict)`
 - Test functions: Don't type hint custom fixtures, optional hints on built-ins for IDE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ uv run ruff format && uv run ruff check --fix && uv run mypy && uv run pytest --
 - If future imports trigger env var reads at collection time, use direct `os.environ["KEY"] = "value"` (never `setdefault()`)
 
 **Fixtures:**
-- Type hints: `MockerFixture` → `MockType` return (strict mypy in conftest.py)
+- Type hints: `MockerFixture` → `MockType` return (CONVENTION ONLY — mypy is scoped to `src/`; conftest typing is enforced by reviewers, see `docs/references/code-quality.md` Test Suite Typing Strategy)
 - Factory pattern (not context managers): `def _factory() -> MockType` returned by fixture
 - Environment mocking: `mocker.patch.dict(os.environ, env_dict)`
 - Test functions: Don't type hint custom fixtures, optional hints on built-ins for IDE
@@ -148,12 +148,7 @@ uv run ruff format && uv run ruff check --fix && uv run mypy && uv run pytest --
 
 **Validation:** Pydantic `@field_validator` (validate at model creation). Tests expect `ValidationError` at `model_validate()`, not at property access. Property simplified with `# pragma: no cover` for impossible edge cases.
 
-**Mypy override:**
-```toml
-[[tool.mypy.overrides]]
-module = "tests.*"
-disable_error_code = "arg-type"
-```
+**Mypy scope:** mypy is scoped to `src/` only. Test bodies are not type-checked; conftest typing is convention enforced by reviewers. Several expected errors surface if you run `uv run mypy src tests` — see `docs/references/code-quality.md` Test Suite Typing Strategy for the full rationale and category list.
 
 **Coverage:** 100% on production code. Exclusions defined in `pyproject.toml`. Test behaviors (errors, edge cases, return values, logging), not just statements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Consolidate Test Suite Typing Strategy as the single source of truth in `docs/references/code-quality.md`, explaining the mypy scope position (src/ only, conftest by convention) and cataloging the categories of expected mypy errors that surface if you run `uv run mypy src tests`. `docs/references/testing.md` and `AGENTS.md` now point to the single source of code quality rationale (#173)
+- Consolidate Test Suite Typing Strategy in `docs/references/code-quality.md` as the single source of truth (mypy scoped to src/, conftest by convention) and catalog expected mypy error categories from `uv run mypy src tests`. `docs/references/testing.md` and `AGENTS.md` now point at it (#173)
 
 ### Removed
 - Dead `[[tool.mypy.overrides]] module = "tests.*"` block from `pyproject.toml`. mypy was already scoped to `packages = ["agent_foundation"]`, so the override never fired — its presence misled readers about what was actually being checked (#173)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Consolidate Test Suite Typing Strategy as the single source of truth in `docs/references/code-quality.md`, explaining the mypy scope position (src/ only, conftest by convention) and cataloging the categories of expected mypy errors that surface if you run `uv run mypy src tests`. `docs/references/testing.md` and `AGENTS.md` now point to the single source of code quality rationale (#173)
+
+### Removed
+- Dead `[[tool.mypy.overrides]] module = "tests.*"` block from `pyproject.toml`. mypy was already scoped to `packages = ["agent_foundation"]`, so the override never fired — its presence misled readers about what was actually being checked (#173)
+
 ## [0.14.0] - 2026-05-13
 
 ### Added

--- a/docs/references/code-quality.md
+++ b/docs/references/code-quality.md
@@ -229,18 +229,45 @@ def greet(name: str | None = None) -> str:
     return f"Hello, {name or 'stranger'}"
 ```
 
-### Per-module Exclusions
+### Test Suite Typing Strategy
 
-From `pyproject.toml`:
+mypy is scoped to the source package. Test modules are not type-checked. Conftest typing is a team convention enforced by reviewers, not by tooling.
+
 ```toml
-[[tool.mypy.overrides]]
-module = "tests.*"
-disable_error_code = "arg-type"  # Allow duck-typed mocks in tests
+[tool.mypy]
+mypy_path = "src"
+packages = ["{your_agent}"]
 ```
 
-**Why:** Test files can pass duck-typed mocks to functions without arg-type errors, enabling pragmatic testing patterns.
+**Why we skip tests:**
+- Drift from `src/` refactors is caught by tests failing at runtime. CI mypy on tests catches the same drift seconds earlier at meaningful config and maintenance cost.
+- Most strict-mypy errors on test code are noise: untyped pytest fixture parameters, duck-typed mocks intentionally standing in for real types, explicit `result = ...; assert result is None` patterns documenting None-return callback variants.
+- Simpler config is more maintainable, especially in a template that downstream projects fork. This matches the common pattern in modern Python projects (Pydantic, FastAPI, and others).
 
-**Important caveat:** We still strictly type `conftest.py` fixture definitions as a team practice (see Team Practices section for rationale).
+**Conftest convention:**
+
+We strict-type fixture definitions in `conftest.py` files as a team practice. mypy doesn't enforce this, but reviewers do.
+
+```python
+# conftest.py — strict typing by convention, not by tooling
+@pytest.fixture
+def mock_state(mocker: MockerFixture) -> MockType:
+    """Mock state with test data."""
+    return mocker.Mock(spec=State)
+```
+
+**Expected errors if you run `uv run mypy src tests`:**
+
+Running mypy across both surfaces will surface several categories of expected errors:
+
+| Error code | Why it's expected |
+|---|---|
+| `no-untyped-def` | pytest injects fixture parameters by name, not by type. Annotating test function parameters adds ceremony without signal. |
+| `func-returns-value` | Pattern `result = callbacks.before_agent(...); assert result is None` documents which ADK callback variants return None. The assertion catches drift if the source signature ever changes. |
+| `attr-defined` | ADK's `App.root_agent` is typed `BaseAgent`, but the runtime instance is a concrete subclass like `LlmAgent`. Tests deliberately access subclass attributes through the parent-typed reference. |
+| `arg-type` | Duck-typed mocks (like `MockMemoryCallbackContext`) intentionally stand in for real types in tests. |
+| `var-annotated` | Bare local-variable assignments in tests where the inferred type is obvious. |
+| `no-any-return` | pytest-mock interactions where the union type returned by `mocker.Mock()` is treated as Any when narrowed through `mocker.patch`. |
 
 ### Inline Exclusions
 
@@ -377,32 +404,6 @@ All checks run automatically in GitHub Actions on every PR:
 - Code quality workflow runs ruff, mypy, pytest
 - Blocks merge if any check fails
 - Ensures main branch always passes quality gates
-
-### Team Practices
-
-**Test Suite Typing Strategy:**
-
-We disable mypy `arg-type` checking for test files, but maintain strict discipline in `conftest.py`:
-
-```python
-# conftest.py - strictly typed even though mypy doesn't enforce it
-@pytest.fixture
-def mock_state() -> MockState:
-    """Create a mock state with test data."""
-    return MockState({"user_id": "user123", "session_data": {"key": "value"}})
-
-@pytest.fixture
-def mock_content() -> MockContent:
-    """Create a mock content with test data."""
-    return MockContent({"text": "Hello, agent!"})
-```
-
-**Why this works:**
-- Test files can pass duck-typed mocks without mypy errors (pragmatic testing)
-- `conftest.py` fixtures have clear type contracts (self-documenting, IDE support)
-- Best of both worlds: strict where it matters, flexible where it helps
-
-This is a **team practice**, not enforced by tooling. Maintain discipline when writing fixtures.
 
 ## Philosophy
 

--- a/docs/references/code-quality.md
+++ b/docs/references/code-quality.md
@@ -240,13 +240,13 @@ packages = ["{your_agent}"]
 ```
 
 **Why we skip tests:**
-- Drift from `src/` refactors is caught by tests failing at runtime. CI mypy on tests catches the same drift seconds earlier at meaningful config and maintenance cost.
+- Drift from `src/` refactors is caught by tests failing at runtime. Running mypy on tests catches the same drift only seconds earlier, but at meaningful config and maintenance cost.
 - Most strict-mypy errors on test code are noise: untyped pytest fixture parameters, duck-typed mocks intentionally standing in for real types, explicit `result = ...; assert result is None` patterns documenting None-return callback variants.
 - Simpler config is more maintainable, especially in a template that downstream projects fork. This matches the common pattern in modern Python projects (Pydantic, FastAPI, and others).
 
 **Conftest convention:**
 
-We strict-type fixture definitions in `conftest.py` files as a team practice. mypy doesn't enforce this, but reviewers do.
+We strictly type fixture definitions in `conftest.py` files as a team practice. mypy doesn't enforce this, but reviewers do.
 
 ```python
 # conftest.py — strict typing by convention, not by tooling

--- a/docs/references/code-quality.md
+++ b/docs/references/code-quality.md
@@ -258,7 +258,7 @@ def mock_state(mocker: MockerFixture) -> MockType:
 
 **Expected errors if you run `uv run mypy src tests`:**
 
-Running mypy across both surfaces will surface several categories of expected errors:
+Running mypy on test modules will surface several categories of expected errors:
 
 | Error code | Why it's expected |
 |---|---|

--- a/docs/references/testing.md
+++ b/docs/references/testing.md
@@ -199,17 +199,9 @@ Test connections between components:
 - Tools are added to agent correctly
 - Configuration flows through system
 
-## Mypy Override for Tests
+## Mypy Scope
 
-Tests use relaxed type checking for pragmatism:
-
-```toml
-[[tool.mypy.overrides]]
-module = "tests.*"
-disable_error_code = ["arg-type"]
-```
-
-Still type hint `conftest.py` fully, but test functions can be more flexible.
+mypy is scoped to the source package. Test modules are not type-checked; conftest typing is a team convention enforced by reviewers. Full rationale and the expected-error categories that surface if you run `uv run mypy src tests` are in [Code Quality → Test Suite Typing Strategy](code-quality.md#test-suite-typing-strategy).
 
 ## Running Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,11 +105,6 @@ warn_unreachable = true
 strict_equality = true
 show_error_codes = true
 
-[[tool.mypy.overrides]]
-module = "tests.*"
-# Allow duck-typed mocks in tests
-disable_error_code = "arg-type"
-
 [tool.coverage.run]
 source = ["src"]
 branch = true


### PR DESCRIPTION
## What

Clarify that mypy is scoped to the source package and test modules are not type-checked. Consolidate the Test Suite Typing Strategy as a single source of truth in `docs/references/code-quality.md` and remove a dead `[[tool.mypy.overrides]] module = "tests.*"` block from `pyproject.toml` that misled readers about what was actually being checked.

## Why

Issue #173 surfaced that the override block in `pyproject.toml` strongly suggested tests were checked with `arg-type` disabled, when in fact mypy was already scoped to `packages = ["agent_foundation"]` and the override never fired. The docs reinforced the misleading picture by repeating the override block in three places. Fix is to make config and docs honest about the position: src/ checked strictly, tests not checked, conftest typing by convention.

## How

- `docs/references/code-quality.md`: replace "Per-module Exclusions" subsection with a new "Test Suite Typing Strategy" section that states the position plainly, explains the reasoning, and catalogs the categories of mypy errors that would surface from `uv run mypy src tests`. Remove the duplicate "Team Practices > Test Suite Typing Strategy" subsection.
- `docs/references/testing.md`: replace "Mypy Override for Tests" section with a brief pointer to the code-quality doc.
- `AGENTS.md`: update fixture-typing bullet and replace dead override block with a one-liner pointing at the code-quality doc.
- `pyproject.toml`: remove the dead `[[tool.mypy.overrides]] module = "tests.*"` block. No behavior change.
- `CHANGELOG.md`: add Changed and Removed entries under `[Unreleased]`.

## Tests

- [x] `uv run ruff format --check && uv run ruff check && uv run mypy && uv run pytest --cov` passes locally
- [x] No code paths touched; doc updates only (plus dead config removal)
- [x] CI green on PR

## Related Issues

Closes #173