### PR TITLE
chore: prepare release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-05-21
+
 ### Changed
 - Consolidate Test Suite Typing Strategy in `docs/references/code-quality.md` as the single source of truth (mypy scoped to src/, conftest by convention) and catalog expected mypy error categories from `uv run mypy src tests`. `docs/references/testing.md` and `AGENTS.md` now point at it (#173)
 
@@ -524,7 +526,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/doughayden/agent-foundation/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/doughayden/agent-foundation/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/doughayden/agent-foundation/compare/v0.12.5...v0.13.0
 [0.12.5]: https://github.com/doughayden/agent-foundation/compare/v0.12.4...v0.12.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.14.0"
+version = "0.14.1"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-05-08T22:15:31.043448Z"
+exclude-newer = "2026-05-16T14:13:53.836878Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -11,7 +11,7 @@ constraints = [{ name = "litellm", specifier = "<=1.82.6" }]
 
 [[package]]
 name = "agent-foundation"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Cut patch release v0.14.1 to anchor downstream syncs (kairos mid-sync) to a tagged version rather than a floating `main` commit.

## Why

Only one merged change since v0.14.0 (#174, closes #173): consolidates the Test Suite Typing Strategy doc and removes a dead mypy override block from `pyproject.toml`. The dead-block removal is technically a config fix (the override never fired given `packages = ["agent_foundation"]`), so a PATCH bump fits semver as well as serving the sync hygiene goal.

## How

- Bump version `0.14.0` → `0.14.1` in `pyproject.toml`, regenerate `uv.lock`
- Convert CHANGELOG `[Unreleased]` to `## [0.14.1] - 2026-05-21`
- Add `[0.14.1]` comparison link, retarget `[Unreleased]` to `v0.14.1...HEAD`

## Tests

- [x] `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest --cov` (74 tests, 100% coverage)
- [x] Pre-commit hooks passed on commit