### PR TITLE
docs: explain DELETE sweep over partition expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Scheduled session-data cleanup via `pg_cron`: a daily job deletes `sessions` older than 90 days (`events` cascade via the FK), closing the `DatabaseSessionService` no-server-side-TTL storage gap. Provisioned with no application code, via the `cloudsql.enable_pg_cron` flag and an idempotent bootstrap in the bastion cloud-init. Runs and failures are observable by default through `cron.job_run_details` and the instance Postgres logs in Cloud Logging (#182)
 - Local Cloud SQL access from the host: `docker-compose.yml` publishes `127.0.0.1:5432:5432`, so a laptop DB client reaches Cloud SQL through the existing IAP tunnel and bastion Auth Proxy as the app SA (#181)
+- Design rationale in `docs/references/cloud-sql.md` for DELETE-based session cleanup over pg_partman partition expiry: ADK owns the schema, idle-based retention keys on the mutable `update_time`, and the bounded sweep keeps the zero-application-code property (#184)
 
 ## [0.14.1] - 2026-05-21
 

--- a/docs/references/cloud-sql.md
+++ b/docs/references/cloud-sql.md
@@ -112,11 +112,11 @@ DELETE FROM sessions WHERE update_time < (now() AT TIME ZONE 'UTC') - interval '
 
 Partition-based retention (dropping time-bucketed partitions, typically managed by pg_partman) is the cleaner expiry mechanism for append-only tables with an immutable time key that the project owns. The session tables fail all three conditions:
 
-- The schema belongs to ADK's `DatabaseSessionService`, and Postgres accepts `PARTITION BY` only at table creation. Partitioning means recreating the tables and owning a divergent copy of upstream's DDL that every ADK schema change must be merged into. The DELETE sweep keeps the zero-application-code property.
+- The schema belongs to ADK's `DatabaseSessionService`, and Postgres accepts `PARTITION BY` only at table creation. Partitioning means recreating the tables and owning a divergent copy of upstream's DDL that every ADK schema change must be merged into. The DELETE sweep keeps the zero-application-code property (retention runs in the database via pg_cron; the app sees ADK's unmodified schema).
 - Retention here means idle for 90 days, so the partition key would have to be `update_time`, which mutates on every event append. Partitioning on the immutable creation timestamp would expire by session age and drop still-active sessions. Partitioning on `update_time` causes cross-partition row movement on the hot write path, which surfaces as serialization errors on concurrent updates.
 - Partitioned tables require the partition key in every primary key and unique constraint, and ADK's session PK does not include a timestamp.
 
-The scale argument also does not arrive: partition drop beats DELETE when the sweep itself is expensive, and this sweep bounds its own input (see Locking and scan cost above). If delete volume ever grows, the first lever is a chunked DELETE (`LIMIT` batches in the job command), a one-line change with no schema surgery. pg_partman would also keep all of the provisioning machinery here, since its retention maintenance is conventionally scheduled through pg_cron.
+The scale argument also does not arrive: partition drop beats DELETE when the sweep itself is expensive, and this sweep bounds its own input (see Locking and scan cost above). If delete volume ever grows, the first lever is batching: Postgres `DELETE` has no `LIMIT` clause, so batch via a `ctid` subquery (`WHERE ctid IN (SELECT ctid ... LIMIT n)`), still a job-command-only change with no schema surgery. pg_partman would also keep all of the provisioning machinery here, since its retention maintenance is conventionally scheduled through pg_cron.
 
 Partition expiry remains the right tool for time-keyed append-only stores the project does own, like an analytics sink with partition-based retention.
 

--- a/docs/references/cloud-sql.md
+++ b/docs/references/cloud-sql.md
@@ -108,6 +108,18 @@ DELETE FROM sessions WHERE update_time < (now() AT TIME ZONE 'UTC') - interval '
 
 **Locking and scan cost.** `DELETE` acquires a `ROW EXCLUSIVE` table-level lock, which conflicts only with `SHARE` and stronger modes, plus `FOR UPDATE` row-level locks on just the rows it deletes, so concurrent reads and writes on other rows proceed unblocked (see [PostgreSQL explicit locking](https://www.postgresql.org/docs/current/explicit-locking.html)). `update_time` is unindexed in the ADK schema, so each run is a sequential scan, and the cleanup itself bounds the table: the scan covers at most the retention window of sessions, once daily, offset from peak hours.
 
+### Why a DELETE sweep, not partition expiry
+
+Partition-based retention (dropping time-bucketed partitions, typically managed by pg_partman) is the cleaner expiry mechanism for append-only tables with an immutable time key that the project owns. The session tables fail all three conditions:
+
+- The schema belongs to ADK's `DatabaseSessionService`, and Postgres accepts `PARTITION BY` only at table creation. Partitioning means recreating the tables and owning a divergent copy of upstream's DDL that every ADK schema change must be merged into. The DELETE sweep keeps the zero-application-code property.
+- Retention here means idle for 90 days, so the partition key would have to be `update_time`, which mutates on every event append. Partitioning on the immutable creation timestamp would expire by session age and drop still-active sessions. Partitioning on `update_time` causes cross-partition row movement on the hot write path, which surfaces as serialization errors on concurrent updates.
+- Partitioned tables require the partition key in every primary key and unique constraint, and ADK's session PK does not include a timestamp.
+
+The scale argument also does not arrive: partition drop beats DELETE when the sweep itself is expensive, and this sweep bounds its own input (see Locking and scan cost above). If delete volume ever grows, the first lever is a chunked DELETE (`LIMIT` batches in the job command), a one-line change with no schema surgery. pg_partman would also keep all of the provisioning machinery here, since its retention maintenance is conventionally scheduled through pg_cron.
+
+Partition expiry remains the right tool for time-keyed append-only stores the project does own, like an analytics sink with partition-based retention.
+
 ### How it is provisioned (no application code)
 
 - **Flag:** `cloudsql.enable_pg_cron = on` in `terraform/main/database.tf`.


### PR DESCRIPTION
## What

Add a Why a DELETE sweep, not partition expiry subsection to the Scheduled Session Cleanup section of `docs/references/cloud-sql.md`, documenting the design rationale for DELETE-based retention over pg_partman partition drops.

## Why

Partition expiry is the textbook-cleaner retention mechanism, so fork maintainers will reasonably ask why the template does not use it. The answer is structural (ADK owns the schema, the retention key mutates, partitioned PK constraints) rather than a simplicity preference, and documenting it at the mechanism's home prevents the question from resurfacing in future reviews.

## How

- New subsection after Locking and scan cost covering: ADK schema ownership vs `PARTITION BY` at creation, idle-based retention vs mutable `update_time` partition key (cross-partition row movement on the hot write path), partition-key PK requirements, the scale threshold where partition drop wins, chunked DELETE as the first escalation lever, and pg_cron remaining the scheduler either way
- Notes where partition expiry is the right tool: time-keyed append-only stores the project owns

## Tests

- [x] Markdown renders correctly (heading hierarchy, list formatting)
- [x] Docs-only change, no code or infrastructure affected