### PR TITLE
chore: prepare release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-04
+
 ### Added
 - Scheduled session-data cleanup via `pg_cron`: a daily job deletes `sessions` older than 90 days (`events` cascade via the FK), closing the `DatabaseSessionService` no-server-side-TTL storage gap. Provisioned with no application code, via the `cloudsql.enable_pg_cron` flag and an idempotent bootstrap in the bastion cloud-init. Runs and failures are observable by default through `cron.job_run_details` and the instance Postgres logs in Cloud Logging (#182)
 - Local Cloud SQL access from the host: `docker-compose.yml` publishes `127.0.0.1:5432:5432`, so a laptop DB client reaches Cloud SQL through the existing IAP tunnel and bastion Auth Proxy as the app SA (#181)
@@ -531,7 +533,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/doughayden/agent-foundation/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/doughayden/agent-foundation/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/doughayden/agent-foundation/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/doughayden/agent-foundation/compare/v0.12.5...v0.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.14.1"
+version = "0.15.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-05-16T14:13:53.836878Z"
+exclude-newer = "2026-05-30T17:57:37.379481Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -11,7 +11,7 @@ constraints = [{ name = "litellm", specifier = "<=1.82.6" }]
 
 [[package]]
 name = "agent-foundation"
-version = "0.14.1"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Prepare the v0.15.0 release: version bump, lockfile sync, and CHANGELOG conversion.

## Why

Two features landed since v0.14.1 (scheduled pg_cron session cleanup and host-published Postgres port), warranting a MINOR release.

## How

- Bump `pyproject.toml` version 0.14.1 → 0.15.0 and run `uv lock`
- Convert CHANGELOG `[Unreleased]` to `## [0.15.0] - 2026-06-04`
- Add new empty `[Unreleased]` section and update comparison links

## Tests

- [x] `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest --cov` — 74 passed, 100% coverage

## Related Issues

Release includes #181, #182, #184