### PR TITLE
chore: prepare release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-04
+
 ### Changed
-- Flatten `src/<pkg>/utils/` into the package root: `utils/config.py` → `config.py`, `utils/observability.py` → `observability.py`; the `utils/__init__.py` re-export facade is removed and `server.py` imports from the modules directly. Forks syncing past this release: apply the same moves, update imports (`from .utils import X` → `from .config import X` / `from .observability import X`), test patch targets (`<pkg>.utils.config.load_dotenv` → `<pkg>.config.load_dotenv` in `conftest.py`), the coverage omit path in `pyproject.toml`, and rename `tests/unit/test_utils_config.py` → `tests/unit/test_config.py` (#186)
-- Reorganize `tests/` into explicit `unit/`, `integration/`, `smoke/`, and `eval/` lane directories. A lane is decided by runtime requirements and determinism; non-unit lanes run by explicit path and `testpaths = ["tests/unit"]` scopes a bare `pytest` to the fast, free, deterministic lane with the 100% coverage gate. Lane markers registered in `pyproject.toml` (#177)
-- Rename `tests/test_config.py` to `tests/unit/test_utils_config.py`, establishing the mirror-source naming convention (`src/<pkg>/utils/config.py` → `test_utils_config.py`) (#177)
+- Flatten `src/<pkg>/utils/` into the package root: `utils/config.py` → `config.py`, `utils/observability.py` → `observability.py`; the `utils/__init__.py` re-export facade is removed and `server.py` imports from the modules directly. Forks syncing past this release: apply the same moves, update imports (`from .utils import X` → `from .config import X` / `from .observability import X`), test patch targets (`<pkg>.utils.config.load_dotenv` → `<pkg>.config.load_dotenv` in `conftest.py`), and the coverage omit path in `pyproject.toml` (#186)
+- Reorganize `tests/` into explicit `unit/`, `integration/`, `smoke/`, and `eval/` lane directories; existing test modules move to `tests/unit/`. A lane is decided by runtime requirements and determinism; non-unit lanes run by explicit path and `testpaths = ["tests/unit"]` scopes a bare `pytest` to the fast, free, deterministic lane with the 100% coverage gate. Lane markers registered in `pyproject.toml` (#177)
+- Establish the mirror-source test naming convention: test module path mirrors source path (`src/<pkg>/config.py` → `tests/unit/test_config.py`); nested source paths flatten with underscores (#177, #186)
 
 ### Removed
 - `tests/test_integration.py`: in-process structural assertions on coverage-omitted modules, not integration tests. App/agent wiring will be validated by the real integration lane, freeing the name for the Postgres + FastAPI suite (#177)
@@ -541,7 +543,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/doughayden/agent-foundation/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/doughayden/agent-foundation/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/doughayden/agent-foundation/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/doughayden/agent-foundation/compare/v0.13.0...v0.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.15.0"
+version = "0.16.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-05-30T17:57:37.379481Z"
+exclude-newer = "2026-05-30T22:52:17.157064Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -11,7 +11,7 @@ constraints = [{ name = "litellm", specifier = "<=1.82.6" }]
 
 [[package]]
 name = "agent-foundation"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Prepare the v0.16.0 release: version bump, CHANGELOG conversion, and release-reader audit of the `[Unreleased]` section.

## Why

Two fork-affecting structural changes are complete and unreleased: the test lane reorganization (#177) and the utils/ package flatten (#186). Releasing them together gives forks one coherent "paths moved" release boundary with a complete migration mapping, before quality-gate feature work starts landing.

## How

- Bump `pyproject.toml` to 0.16.0 and run `uv lock` (committed together)
- Convert `[Unreleased]` to `[0.16.0] - 2026-06-04`; add fresh empty `[Unreleased]`; update comparison links
- Release-reader audit: the `test_config.py` → `test_utils_config.py` → `test_config.py` rename chain across #177/#186 netted out to a directory move, so the entries now state the final shape (move to `tests/unit/`, mirror-source convention) and the never-shipped intermediate name is gone from the fork migration steps

## Tests

- [x] Full gate green: `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest --cov` — 68 passed, 100.00% coverage
- [x] `uv lock` run with the version bump (CI `--locked` will validate)
- [x] Comparison links verified against `git remote -v` (origin)

## Related Issues

Releases #177 and #186 work (issues already closed by PRs #187, #188).