### PR TITLE
chore: prepare release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-08
+
 ### Added
 - `docs/references/image-digest-resolution.md`: how one build surfaces as different digests across Artifact Registry tags (OCI index), Cloud Run revisions (platform manifest), and the provenance attestation — with resolution commands, console paths, and digest-based debugging recipes. Restores and modernizes content dropped in the February docs refactor
 - `verify-image-provenance` project skill: operationalizes the digest-resolution doc as a deterministic procedure (`resolve_chain.sh` with service/compare/revision/tag/classify/find-commit modes) answering image-identity questions with digest evidence — same-image checks across revisions, running-image-to-commit/PR attribution, artifact classification, and deploy-chain verification. Eval-validated across models
+
+### Changed
+- `sync-foundation` skill: add a doc-reuse principle to Phase 8 (Documentation) mirroring the Phase 1 fixture-reuse principle — prefer verbatim reuse of upstream docs and isolate unavoidable divergence into bounded blocks, so future syncs evaluate docs as fast verbatim diffs rather than line-by-line reconciliation (#191)
 
 ## [0.16.0] - 2026-06-04
 
@@ -547,7 +552,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/doughayden/agent-foundation/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/doughayden/agent-foundation/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/doughayden/agent-foundation/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/doughayden/agent-foundation/compare/v0.14.0...v0.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.16.0"
+version = "0.17.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-05-30T22:52:17.157064Z"
+exclude-newer = "2026-06-03T13:06:23.445614Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -11,7 +11,7 @@ constraints = [{ name = "litellm", specifier = "<=1.82.6" }]
 
 [[package]]
 name = "agent-foundation"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },


### PR DESCRIPTION
## What

Prepare the v0.17.0 release: version bump, lockfile sync, and CHANGELOG cut.

## Why

The unreleased range since v0.16.0 ships a new feature — the `verify-image-provenance` skill (#190) — plus a sync-foundation skill enhancement (#191). A new feature is a MINOR bump under SemVer (pre-1.0), so this is v0.17.0, not a patch.

## How

- Bump `pyproject.toml` version 0.16.0 → 0.17.0 and refresh `uv.lock`.
- Convert CHANGELOG `[Unreleased]` to `[0.17.0] - 2026-06-08`; add a fresh empty `[Unreleased]`.
- Add a `Changed` entry for the sync-foundation Phase 8 doc-reuse principle (#191).
- Update comparison links (`v0.16.0...v0.17.0`, new `[Unreleased]` base).

## Tests

- [x] `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest --cov` — all pass, 100% coverage (68 tests)
- [x] `uv.lock` reflects 0.17.0 (CI `--locked` will pass)
- [x] CHANGELOG comparison links resolve (v0.16.0...v0.17.0)