### PR TITLE
chore: exclude .claude/ from fix-in-place hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,11 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
+      # The Claude Code sandbox write-denies .claude/, so fix-in-place hooks error there
       - id: trailing-whitespace
+        exclude: ^\.claude/
       - id: end-of-file-fixer
+        exclude: ^\.claude/
       - id: check-yaml
         args: [--unsafe]
       - id: check-toml


### PR DESCRIPTION
## What

Exclude `.claude/` from the `trailing-whitespace` and `end-of-file-fixer` pre-commit hooks.

## Why

The Claude Code sandbox write-denies `.claude/`. When a fix-in-place hook tries to rewrite a file there, it errors and blocks the commit.

## How

- Add `exclude: ^\.claude/` to `trailing-whitespace`
- Add `exclude: ^\.claude/` to `end-of-file-fixer`
- Add a comment explaining the exclusion

## Tests

- [x] Pre-commit hooks pass on commit (verified in the commit run)