### PR TITLE
chore: remove litellm supply-chain constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgrade `google-adk` to 2.2.0 and declare its `[gcp,otel-gcp]` extras. ADK 2.x no longer pulls the Vertex/Agent Engine (`aiplatform`), GCS, and GCP OpenTelemetry dependencies by default; the extras restore them for the Agent Engine memory service, the GCS artifact service, and Cloud Trace/Logging export. Raise the `opentelemetry-instrumentation-google-genai` floor to `>=0.7b1` (earlier builds capped `google-genai<2` and silently skipped GenAI instrumentation under ADK 2.x)
 
+### Removed
+- Drop the preventive `litellm<=1.82.6` constraint-dependency. The supply-chain compromise that prompted it is contained: the two malicious versions (1.82.7, 1.82.8) are deleted from PyPI and all current releases are verified clean ([BerriAI/litellm#24518](https://github.com/BerriAI/litellm/issues/24518)). The `exclude-newer` dependency cooldown remains the general guard against newly-compromised packages, so no version-specific litellm pin is needed. Unblocks the `google-adk[eval]` extra
+
 ## [0.17.0] - 2026-06-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,6 @@ build-backend = "uv_build"
 [tool.uv]
 # https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns
 exclude-newer = "5 days"
-# Preventive constraint: if litellm ever enters the dependency tree (e.g., via ADK),
-# ensure we don't get compromised versions until BerriAI publishes a verified safe release
-# https://github.com/BerriAI/litellm/issues/24518
-# https://docs.astral.sh/uv/reference/settings/#constraint-dependencies
-constraint-dependencies = ["litellm<=1.82.6"]
 
 [tool.ruff]
 src = ["src"]

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ requires-python = "==3.13.*"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P5D"
 
-[manifest]
-constraints = [{ name = "litellm", specifier = "<=1.82.6" }]
-
 [[package]]
 name = "agent-foundation"
 version = "0.17.0"


### PR DESCRIPTION
## What

Remove the preventive `litellm<=1.82.6` constraint-dependency from `pyproject.toml` (and the corresponding `uv.lock` manifest entry).

## Why

The constraint was added in #130 as a supply-chain guard after the litellm PyPI compromise ([BerriAI/litellm#24518](https://github.com/BerriAI/litellm/issues/24518)). That incident is now contained:

- The two malicious versions, 1.82.7 and 1.82.8, were uploaded directly to PyPI by a hijacked maintainer account, never through official CI/CD.
- Both are deleted from PyPI (verified: each returns HTTP 404), so no resolver can select them.
- All releases from 1.83.0 onward are verified clean by the maintainers, accounts rotated, CI/CD hardened.

With the bad versions gone and every installable version clean, there is no version-specific litellm pin worth keeping. The `exclude-newer = "5 days"` cooldown stays as the general guard against any newly-compromised package, covering every dependency rather than just litellm. A range pin like `>=x,<2.0.0` would add no safety here and would silently cap a transitive package for the whole project.

## How

- Drop the `constraint-dependencies` line and its comment block from `[tool.uv]`; keep `exclude-newer`
- `uv lock` (removes the litellm constraint from the lock manifest)
- CHANGELOG `[Unreleased]` Removed entry

## Tests

- [x] `uv sync --locked` consistent
- [x] ruff format, ruff check, mypy clean
- [x] 68 unit tests pass

## Follow-up

Unblocks the `google-adk[eval]` extra. PR #201 currently pins `rouge-score`/`pandas`/`tabulate` individually to work around this constraint; that workaround can be replaced with the extra once this lands.