### PR TITLE
docs: generalize package references for downstream forks

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -224,7 +224,7 @@ See [Development](development.md) for the full local development workflow includ
 Authenticate to the deployed agent service using the Cloud Run proxy.
 
 ```bash
-# Service name format: ${AGENT_NAME}-${environment} (e.g., agent-foundation-dev)
+# Service name format: ${AGENT_NAME}-${environment} (e.g., your-agent-dev)
 gcloud run services proxy <service-name> --project <project-id> --region <region> --port 8000
 
 # In another terminal, test the health endpoint

--- a/docs/references/agent-evals.md
+++ b/docs/references/agent-evals.md
@@ -52,17 +52,22 @@ Calls `AgentEvaluator.evaluate()` against `test_config.json`, which raises on a 
 
 ### The CLI: `adk eval`
 
+The `adk` commands take the agent package directory. Set it once (the template has a single package under `src/`); the later examples reuse it:
+
 ```bash
+# The agent package dir (single package under src/)
+AGENT_PACKAGE=$(basename src/*/)
+
 # Gate criteria, with detailed per-metric output
-adk eval src/agent_foundation eval/data/template_agent.evalset.json \
+adk eval src/$AGENT_PACKAGE eval/data/template_agent.evalset.json \
   --config_file_path eval/data/test_config.json --print_detailed_results
 
 # The scripted multi-turn case
-adk eval src/agent_foundation eval/data/multi_turn.evalset.json \
+adk eval src/$AGENT_PACKAGE eval/data/multi_turn.evalset.json \
   --config_file_path eval/data/test_config.json
 
 # Deep run: judge, rubric, hallucination, and safety metrics
-adk eval src/agent_foundation eval/data/template_agent.evalset.json \
+adk eval src/$AGENT_PACKAGE eval/data/template_agent.evalset.json \
   --config_file_path eval/data/full_eval_config.json --print_detailed_results
 ```
 
@@ -79,20 +84,20 @@ adk test eval/data   # runs every *.test.json, criteria from the adjacent test_c
 An LLM plays the user across a multi-turn conversation, following a plan and persona instead of a fixed script. Build an eval set from the shipped scenarios, then run it. Only `hallucinations_v1`, `safety_v1`, and the simulator and multi-turn metrics apply here, because there is no fixed expected response to match against.
 
 ```bash
-adk eval_set create src/agent_foundation user_sim_demo
-adk eval_set add_eval_case src/agent_foundation user_sim_demo \
+adk eval_set create src/$AGENT_PACKAGE user_sim_demo
+adk eval_set add_eval_case src/$AGENT_PACKAGE user_sim_demo \
   --scenarios_file eval/data/conversation_scenarios.json \
   --session_input_file eval/data/session_input.json
-adk eval src/agent_foundation user_sim_demo \
+adk eval src/$AGENT_PACKAGE user_sim_demo \
   --config_file_path eval/data/user_sim_config.json --print_detailed_results
 ```
 
-`adk eval_set` writes the eval set to the agent package as `src/agent_foundation/<eval_set_id>.evalset.json` (gitignored as generated scratch; copy anything worth keeping into `eval/data/`). To keep generated eval sets out of the package entirely, pass `--eval_storage_uri gs://<bucket>` to every `adk eval_set` command and to `adk eval`; the eval set is then stored in and read from that GCS bucket. A cloud bucket is the only storage override, local paths are not configurable.
+`adk eval_set` writes the eval set to the agent package as `src/$AGENT_PACKAGE/<eval_set_id>.evalset.json` (gitignored as generated scratch; copy anything worth keeping into `eval/data/`). To keep generated eval sets out of the package entirely, pass `--eval_storage_uri gs://<bucket>` to every `adk eval_set` command and to `adk eval`; the eval set is then stored in and read from that GCS bucket. A cloud bucket is the only storage override, local paths are not configurable.
 
 To synthesize scenarios instead of writing them by hand:
 
 ```bash
-adk eval_set generate_eval_cases src/agent_foundation user_sim_generated \
+adk eval_set generate_eval_cases src/$AGENT_PACKAGE user_sim_generated \
   --user_simulation_config_file generation_config.json
 ```
 
@@ -103,7 +108,7 @@ where `generation_config.json` looks like `{"count": 5, "model_name": "gemini-2.
 ADK ships a GEPA prompt optimizer that rewrites the root agent's instructions against a target metric, driven by an optimizer config file:
 
 ```bash
-adk optimize src/agent_foundation <optimizer_config_path>
+adk optimize src/$AGENT_PACKAGE <optimizer_config_path>
 ```
 
 It is long-running and makes multiple LLM calls. Treat it as a last resort after manual instruction fixes, and run a single pass rather than looping on it. See `adk optimize --help` for the config format.
@@ -140,7 +145,7 @@ The `agent-eval` job in `.github/workflows/ci.yml` runs `uv run pytest eval` on 
 
 1. Capture or write a case: `SERVE_WEB_INTERFACE=TRUE uv run server` (Eval tab), or hand-edit a file in `eval/data/`.
 2. Pin the expected tool trajectory (exact name and args) and a reference response built from stable tokens, no dates or clock values, so ROUGE stays stable against the real LLM.
-3. Replay: `adk eval src/agent_foundation <evalset> --config_file_path eval/data/test_config.json`.
+3. Replay: `adk eval src/$AGENT_PACKAGE <evalset> --config_file_path eval/data/test_config.json`.
 4. Validate non-flaky: run `uv run pytest eval` at least three times before relying on a new gate case.
 
 See ADK's [evaluation docs](https://adk.dev/evaluate/) for the authoring workflow, the `EvalSet` schema, and migration utilities.

--- a/docs/references/testing.md
+++ b/docs/references/testing.md
@@ -32,7 +32,7 @@ The integration lane (`tests/integration/`) exercises the real FastAPI app again
 Start an ephemeral Postgres container, run the lane, then tear it down:
 
 ```bash
-docker run -d --rm --name agent-foundation-pg \
+docker run -d --rm --name your-agent-pg \
   -p 127.0.0.1:5432:5432 \
   -e POSTGRES_USER=postgres \
   -e POSTGRES_PASSWORD=postgres \
@@ -41,7 +41,7 @@ docker run -d --rm --name agent-foundation-pg \
 
 uv run pytest tests/integration
 
-docker stop agent-foundation-pg
+docker stop your-agent-pg
 ```
 
 The connection defaults to `postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/sessions`. Override it with the `INTEGRATION_DATABASE_URI` environment variable to point at a different host or port. This is a test-harness variable, not application runtime config, so it lives here rather than in `docs/environment-variables.md`.
@@ -70,16 +70,16 @@ The `ci.yml` `integration` job runs a `postgres:17` service container (with a `p
 
 ### Directory Structure
 
-Lanes are top-level directories; unit test modules mirror source structure:
+Lanes are top-level directories; unit test modules mirror source structure (`your-agent/src/your_agent/...`):
 
 ```
 eval/                            # LLM eval lane
 tests/
   conftest.py                    # Shared fixtures, mocks, and test environment setup (all lanes)
   unit/
-    test_callbacks.py            # Tests for src/agent_foundation/callbacks.py
-    test_tools.py                # Tests for src/agent_foundation/tools.py
-    test_config.py               # Tests for src/agent_foundation/config.py
+    test_callbacks.py            # Tests for src/your_agent/callbacks.py
+    test_tools.py                # Tests for src/your_agent/tools.py
+    test_config.py               # Tests for src/your_agent/config.py
     ...
   integration/                   # Postgres + FastAPI lane
   smoke/                         # Live deployed-URL lane

--- a/docs/references/testing.md
+++ b/docs/references/testing.md
@@ -70,7 +70,7 @@ The `ci.yml` `integration` job runs a `postgres:17` service container (with a `p
 
 ### Directory Structure
 
-Lanes are top-level directories; unit test modules mirror source structure (`your-agent/src/your_agent/...`):
+Lanes are top-level directories; unit test modules mirror source structure:
 
 ```
 eval/                            # LLM eval lane

--- a/docs/template-management.md
+++ b/docs/template-management.md
@@ -26,7 +26,7 @@ One-time configuration:
 
 ```bash
 # Add template repository as foundation remote
-git remote add foundation https://github.com/your-org/agent-foundation.git
+git remote add foundation https://github.com/doughayden/agent-foundation.git
 git remote -v  # Verify
 
 # Fetch foundation tags to refs/foundation-tags/* (avoids conflicts with local tags)

--- a/init_template.py
+++ b/init_template.py
@@ -559,8 +559,9 @@ def main() -> NoReturn:
         compose_files = Path().glob("docker-compose*.yml")
         files_to_update.extend(str(path) for path in compose_files)
 
-        # Glob the docs directory
-        doc_files = Path("docs").rglob("*.md")
+        # Skip template-management.md: its foundation refs must survive forking.
+        skip_docs = {Path("docs/template-management.md")}
+        doc_files = (p for p in Path("docs").rglob("*.md") if p not in skip_docs)
         files_to_update.extend(str(path) for path in doc_files)
 
         # Glob the test suite


### PR DESCRIPTION
## What

Removes hardcoded `agent_foundation` package references from the reference docs so downstream forks read them without mental find-and-replace, and stops `init_template.py` from rewriting the one guide that must keep pointing at the foundation.

## Why

The eval and testing docs shipped copy-paste commands and paths naming the template's own package (`agent_foundation`). A fork reading them on GitHub, or one that skips `init_template.py`, sees a name that is not theirs. The template-management guide is the opposite case: its `foundation-tag` diffs and `foundation` remote intentionally reference the foundation, so the init script must not rewrite them.

## How

- `docs/references/agent-evals.md`: derive the package once with `AGENT_PACKAGE=$(basename src/*/)` in the CLI section and use `src/$AGENT_PACKAGE` across every `adk` command and the one prose path. This doc keeps the shell-variable form because its commands are meant to be run as-is; the others use plain `your_agent` placeholders.
- `docs/references/testing.md`, `docs/getting-started.md`: replace `agent_foundation` / `agent-foundation-*` examples with `your_agent` / `your-agent` placeholders, each doc self-consistent.
- `docs/template-management.md`: point the `foundation` remote at `doughayden/agent-foundation` (the real upstream); its foundation-side `agent_foundation` references stay as-is.
- `init_template.py`: skip `docs/template-management.md` when rewriting docs at fork time, so its foundation package and remote-URL references survive.

After the sweep, `agent_foundation` appears only in `docs/template-management.md`, by design.

## Tests

- [x] `uv run ruff format --check init_template.py && uv run ruff check init_template.py` clean
- [x] `uv run mypy` clean (no issues in 8 source files)
- [x] `uv run pytest -q` green (76 passed; docs/script change has no test impact)
- [x] `grep -rlE "agent_foundation" docs/` returns only `docs/template-management.md`
- [x] `init_template.py` skip verified: `template-management.md` excluded, the other 25 docs still processed