### PR TITLE
fix: keep the global instruction prefix cache-stable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Entry-point map for "I want to add X". Each row points to the file where the cha
 |---|---|---|
 | Add a custom tool | define `func` in `tools.py` + register in `agent.py` | `root_agent = LlmAgent(..., tools=[..., FunctionTool(func)])` |
 | Add a callback | `callbacks.py` | ADK callbacks return `None` to observe, or a modified value to mutate/short-circuit — choose per intent |
-| Customize agent instructions | `prompt.py` | InstructionProvider pattern (function ref, called at runtime) |
+| Customize agent instructions | `prompt.py` | InstructionProvider pattern (function ref, called at runtime). Keep per-turn-volatile values (wall-clock time, request IDs) out of the returned string: it is the cached system-instruction prefix, so volatility there busts prompt caching every turn. Expose precise time via a tool (`get_current_time`) instead |
 | Add an agent eval case | `eval/data/*.evalset.json` | Deterministic gate criteria in `test_config.json` (auto-discovered); judge/rubric/safety criteria in `full_eval_config.json`, user-simulation in `conversation_scenarios.json` + `user_sim_config.json` (none in the PR gate). Validate non-flaky: run `uv run pytest eval` ≥3 times. `adk eval`/`uv run server` (Eval tab) are authoring tools only — the `adk eval` CLI exits 0 on failed cases, never gate CI on it. Full surface + commands: `docs/references/agent-evals.md` |
 | Add an env var | `ServerEnv` in `config.py` + `docs/environment-variables.md` | **CRITICAL:** every new env var MUST be in `docs/environment-variables.md` (purpose, default, where to set, required/optional) |
 | Enable a GCP API | `terraform/main/services.tf` | `google_project_service`; downstream resources `depends_on = [time_sleep.service_enablement_propagation["api.googleapis.com"]]` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Drop the preventive `litellm<=1.82.6` constraint-dependency. The supply-chain compromise that prompted it is contained: the two malicious versions (1.82.7, 1.82.8) are deleted from PyPI and all current releases are verified clean ([BerriAI/litellm#24518](https://github.com/BerriAI/litellm/issues/24518)). The `exclude-newer` dependency cooldown remains the general guard against newly-compromised packages, so no version-specific litellm pin is needed. Unblocks the `google-adk[eval]` extra
 
+### Fixed
+- Drop the per-turn microsecond timestamp from the global instruction; use day-precision date so the cached system-instruction prefix holds across a session, fixing Gemini/Anthropic prompt-cache misses every turn (#199)
+
 ## [0.17.0] - 2026-06-08
 
 ### Added

--- a/src/agent_foundation/prompt.py
+++ b/src/agent_foundation/prompt.py
@@ -8,22 +8,26 @@ from google.adk.agents.readonly_context import ReadonlyContext
 def return_global_instruction(ctx: ReadonlyContext) -> str:
     """Generate global instruction with current date, day of week, and user ID.
 
-    Uses InstructionProvider pattern to ensure date updates at request time.
-    GlobalInstructionPlugin expects signature: (ReadonlyContext) -> str
+    Uses the InstructionProvider pattern so the date is evaluated at request
+    time. GlobalInstructionPlugin expects signature: (ReadonlyContext) -> str.
+
+    Date precision only (no clock time): a per-turn value here would bust
+    prompt caching, since this string is the cached instruction prefix.
 
     Args:
         ctx: ReadonlyContext providing access to session metadata including
              user_id for queries and memory operations.
 
     Returns:
-        str: Global instruction with UTC timestamp, day name for work week
+        str: Global instruction with the current date, day name for work-week
              calculations (Sunday-Saturday timecard periods), and user ID.
     """
     now_utc = datetime.now(UTC)
+    today = now_utc.strftime("%Y-%m-%d")
     day_name = now_utc.strftime("%A")
     return (
         "\n\nYou are a helpful Assistant.\n"
-        f"Current UTC timestamp: {now_utc} ({day_name})\n"
+        f"Current date: {today} ({day_name})\n"
         f"Current User's ID: {ctx.user_id}"
     )
 


### PR DESCRIPTION
## What

Drops the per-turn microsecond timestamp from the agent's global (system) instruction, using a day-precision date instead.

## Why

`return_global_instruction` injected a full microsecond UTC timestamp near the top of the system instruction, regenerated every turn. Because that sits in the cacheable prefix, both Gemini context caching and Anthropic prompt caching missed on every request in a session, so each turn paid full prefix reprocessing in latency and cost. The ADK 2.2.0 dev UI "System Instruction Performance Analysis" flagged it: only the timestamp changed between consecutive turns. The docstring's functional need is the date and weekday (work-week reasoning), not sub-day precision, so the timestamp was pure cache-buster. This ships in the template's default prompt, so every fork inherited the tax.

## How

- `prompt.py`: emit `Current date: YYYY-MM-DD (Weekday)` via `now_utc.strftime("%Y-%m-%d")` instead of the full datetime. The prefix now changes once per day, holding the cache across any normal session. The user ID line was already stable within a session and is unchanged.
- `AGENTS.md`: the `prompt.py` extension-point row now records the general rule, keep per-turn-volatile values out of the returned string (it is the cached prefix), and expose precise time via the `get_current_time` tool.
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

No precise-time behavior is lost: the agent already has a `get_current_time` tool to call when it needs the actual clock.

## Tests

- [x] `uv run ruff format --check && uv run ruff check` clean
- [x] `uv run mypy` clean (8 source files)
- [x] `uv run pytest --cov` green (76 passed, 100% coverage; `prompt.py` is coverage-omitted, no test delta)
- [x] Rendered instruction confirmed day-precision: `Current date: 2026-06-16 (Tuesday)` (no microseconds)
- [ ] CI `agent-eval` job: deterministic eval still passes against the real model (runs on this PR; the eval lane can't run in the local sandbox)

Closes #199