### PR TITLE
chore: prepare release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-15
+
 ### Added
 - Integration test lane (`tests/integration/`): exercises the real FastAPI app against a real Postgres session service with no mocks, covering session create/list/get/delete, an agent run that persists and reads session state, and FK cascade-on-delete (a raw `DELETE` on `sessions` removes the session's events through the Postgres `ON DELETE CASCADE`, the database-level path the `pg_cron` retention job relies on). Builds the production app via ADK `get_fast_api_app()` with a `postgresql+asyncpg://` URI and drives it in-process with httpx `ASGITransport`; the LLM is stubbed so the lane is deterministic and free. Includes a Postgres-dialect strictness test (asyncpg rejects ISO strings for `timestamptz` where sqlite tolerates them). Runs in the `ci.yml` required check via a `postgres:17` service container, gated on `changes` and folded into the `CI / status` sentinel, without `--cov` (#102)
 - Agent eval harness in a top-level `eval/` lane (separate from `tests/` because it calls the live model): `eval/data/template_agent.evalset.json` (ADK `EvalSet` schema) with a deterministic `get_current_time` tool-trajectory case, and `test_config.json` deterministic PR-gate criteria (`tool_trajectory_avg_score` IN_ORDER 1.0 + `response_match_score` ROUGE-1 0.4) (#104)
@@ -571,7 +573,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/doughayden/agent-foundation/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/doughayden/agent-foundation/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/doughayden/agent-foundation/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/doughayden/agent-foundation/compare/v0.14.1...v0.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.17.0"
+version = "0.18.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "agent-foundation"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk", extra = ["gcp", "otel-gcp"] },


### PR DESCRIPTION
## What

Prepare the v0.18.0 release: version bump, lockfile refresh, and CHANGELOG conversion.

## Why

Cut a minor release for the test-infrastructure and prompt-cache work merged since v0.17.0. The new backward-compatible features (agent eval lane, Postgres integration lane) make this a minor bump per pre-1.0 semver, not a patch.

## How

- Bump `pyproject.toml` version 0.17.0 → 0.18.0 and refresh `uv.lock`
- Convert CHANGELOG `[Unreleased]` → `[0.18.0] - 2026-06-15`, add a fresh empty `[Unreleased]`
- Add the v0.18.0 comparison link and retarget `[Unreleased]`

Release contents:
- Added: agent eval harness (top-level `eval/` lane, deterministic PR gate, full ADK eval surface) (#104); Postgres integration lane (#102)
- Changed: `google-adk` upgraded to 2.2.0 with `[gcp,otel-gcp]` extras (#200)
- Removed: preventive `litellm<=1.82.6` constraint (#203)
- Fixed: per-turn timestamp dropped from the global instruction for prompt-cache stability (#199)

## Tests

- [x] `uv run ruff format && uv run ruff check && uv run mypy` clean
- [x] `uv run pytest --cov` green (76 passed, 100% coverage)
- [x] `uv.lock` in sync with `pyproject.toml` (uv-lock pre-commit hook passed)