### PR TITLE
feat: add post-deploy end-to-end smoke tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'src/**'
+      - 'tests/smoke/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'Dockerfile'
@@ -16,11 +17,13 @@ on:
       - '.github/workflows/metadata-extract.yml'
       - '.github/workflows/pull-and-promote.yml'
       - '.github/workflows/resolve-image-digest.yml'
+      - '.github/workflows/smoke.yml'
       - '.github/workflows/terraform-plan-apply.yml'
   push:
     branches: [main]
     paths:
       - 'src/**'
+      - 'tests/smoke/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'Dockerfile'
@@ -32,6 +35,7 @@ on:
       - '.github/workflows/metadata-extract.yml'
       - '.github/workflows/pull-and-promote.yml'
       - '.github/workflows/resolve-image-digest.yml'
+      - '.github/workflows/smoke.yml'
       - '.github/workflows/terraform-plan-apply.yml'
     tags:
       - 'v*'
@@ -107,6 +111,16 @@ jobs:
       use_saved_plan: ${{ github.event_name == 'push' }}  # Matches the dev-plan job's save_plan pattern
     secrets: inherit
 
+  # Post-deploy smoke against the live dev revision (same gate as dev-apply)
+  smoke-dev:
+    name: Smoke Dev
+    if: github.ref_type == 'branch' && github.event_name == 'push'
+    needs: dev-apply
+    uses: ./.github/workflows/smoke.yml
+    with:
+      environment: dev
+    secrets: inherit
+
   # Stage environment (merge to main only, not PRs or tags, wait for dev to deploy)
   stage-promote:
     name: Promote to Stage
@@ -142,6 +156,16 @@ jobs:
       docker_image: ${{ needs.stage-promote.outputs.digest_uri }}
       terraform_action: apply
       use_saved_plan: true
+    secrets: inherit
+
+  # Post-deploy smoke against the live stage revision (production mode only)
+  smoke-stage:
+    name: Smoke Stage
+    if: needs.config.outputs.production_mode == 'true' && github.ref_type == 'branch' && github.event_name == 'push'
+    needs: [config, stage-apply]
+    uses: ./.github/workflows/smoke.yml
+    with:
+      environment: stage
     secrets: inherit
 
   # Production environment (tag events only)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - 'src/**'
-      - 'tests/smoke/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'Dockerfile'
@@ -23,7 +22,6 @@ on:
     branches: [main]
     paths:
       - 'src/**'
-      - 'tests/smoke/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'Dockerfile'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -50,10 +50,11 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
-      - name: Resolve deployed service URL and invoker token
-        id: target
+      - name: Resolve target, mint token, and run smoke tests
+        id: smoke
+        shell: bash {0}  # Removes -e flag so pytest's exit code is captured for the summary
         run: |
-          set -euo pipefail
+          set -uo pipefail
           SERVICE="${IMAGE_NAME}-${ENV}"
 
           # Service naming is ${agent_name}-${environment}; agent_name == vars.IMAGE_NAME.
@@ -61,51 +62,50 @@ jobs:
             --region "$REGION" \
             --format='value(urls[0])')
           if [ -z "$SERVICE_URL" ]; then
-            echo "::error::No serving URL for $SERVICE in $REGION — the revision did not deploy"
+            echo "::error::No serving URL for $SERVICE in $REGION. The revision did not deploy."
             exit 1
           fi
 
           # Resolve the invoker SA by display name (decoupled from the 30-char account_id truncation).
+          # --limit=1 plus an explicit single-line check guards against a duplicate display name
+          # (e.g. a TF replace in flight) yielding multiple newline-separated emails.
           SMOKE_SA=$(gcloud iam service-accounts list \
             --filter="displayName='${SERVICE} Smoke Invoker'" \
-            --format='value(email)')
+            --format='value(email)' \
+            --limit=1)
           if [ -z "$SMOKE_SA" ]; then
             echo "::error::No smoke invoker SA found for $SERVICE"
             exit 1
           fi
+          if [ "$(printf '%s' "$SMOKE_SA" | grep -c '')" -ne 1 ]; then
+            echo "::error::Multiple smoke invoker SAs matched '${SERVICE} Smoke Invoker'"
+            exit 1
+          fi
 
           # Mint a Cloud Run ID token by impersonating the invoker SA (audience = service URL).
+          # Kept as a local shell var so the token never reaches $GITHUB_OUTPUT or the summary.
           ID_TOKEN=$(gcloud auth print-identity-token \
             --impersonate-service-account="$SMOKE_SA" \
             --audiences="$SERVICE_URL")
-
-          echo "service_url=$SERVICE_URL" >> "$GITHUB_OUTPUT"
           echo "::add-mask::$ID_TOKEN"
-          echo "id_token=$ID_TOKEN" >> "$GITHUB_OUTPUT"
           echo "Resolved $SERVICE -> $SERVICE_URL (invoker: $SMOKE_SA)"
 
-      - name: Run smoke tests
-        id: smoke
-        shell: bash {0}  # Removes -e flag to allow capturing output on failure
-        env:
-          SMOKE_BASE_URL: ${{ steps.target.outputs.service_url }}
-          SMOKE_ID_TOKEN: ${{ steps.target.outputs.id_token }}
-        run: |
           OUTPUT_FILE=$(mktemp)
 
           # Stream to logs (real-time) and a file (for the summary), capturing pytest's exit code.
-          uv run pytest tests/smoke 2>&1 | tee "$OUTPUT_FILE"
+          SMOKE_BASE_URL="$SERVICE_URL" SMOKE_ID_TOKEN="$ID_TOKEN" \
+            uv run pytest tests/smoke 2>&1 | tee "$OUTPUT_FILE"
           EXIT_CODE=${PIPESTATUS[0]}  # pytest's exit code, not tee's
 
           {
-            echo "## 🔥 Smoke Tests (${ENV})"
+            echo "## Smoke Tests (${ENV})"
             echo ""
-            echo "Target: \`${SMOKE_BASE_URL}\`"
+            echo "Target: \`${SERVICE_URL}\`"
             echo ""
             if [ "$EXIT_CODE" -eq 0 ]; then
-              echo "✅ All smoke checks passed against the deployed revision."
+              echo "PASSED: all smoke checks passed against the deployed revision."
             else
-              echo "❌ Smoke checks failed (exit ${EXIT_CODE}) — the revision is not serving correctly."
+              echo "FAILED: smoke checks failed (exit ${EXIT_CODE}). The revision is not serving correctly."
             fi
             echo ""
             echo '<details><summary>pytest output</summary>'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,6 +23,7 @@ jobs:
       ENV: ${{ inputs.environment }}
       IMAGE_NAME: ${{ vars.IMAGE_NAME }}
       REGION: ${{ vars.REGION }}
+      GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -59,6 +60,7 @@ jobs:
 
           # Service naming is ${agent_name}-${environment}; agent_name == vars.IMAGE_NAME.
           SERVICE_URL=$(gcloud run services describe "$SERVICE" \
+            --project "$GOOGLE_CLOUD_PROJECT" \
             --region "$REGION" \
             --format='value(urls[0])')
           if [ -z "$SERVICE_URL" ]; then
@@ -70,6 +72,7 @@ jobs:
           # Return all matches so a duplicate display name (e.g. a TF replace in flight) yields
           # multiple newline-separated emails and the single-line check below aborts.
           SMOKE_SA=$(gcloud iam service-accounts list \
+            --project "$GOOGLE_CLOUD_PROJECT" \
             --filter="displayName='${SERVICE} Smoke Invoker'" \
             --format='value(email)')
           if [ -z "$SMOKE_SA" ]; then

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -67,12 +67,11 @@ jobs:
           fi
 
           # Resolve the invoker SA by display name (decoupled from the 30-char account_id truncation).
-          # --limit=1 plus an explicit single-line check guards against a duplicate display name
-          # (e.g. a TF replace in flight) yielding multiple newline-separated emails.
+          # Return all matches so a duplicate display name (e.g. a TF replace in flight) yields
+          # multiple newline-separated emails and the single-line check below aborts.
           SMOKE_SA=$(gcloud iam service-accounts list \
             --filter="displayName='${SERVICE} Smoke Invoker'" \
-            --format='value(email)' \
-            --limit=1)
+            --format='value(email)')
           if [ -z "$SMOKE_SA" ]; then
             echo "::error::No smoke invoker SA found for $SERVICE"
             exit 1
@@ -87,6 +86,10 @@ jobs:
           ID_TOKEN=$(gcloud auth print-identity-token \
             --impersonate-service-account="$SMOKE_SA" \
             --audiences="$SERVICE_URL")
+          if [ -z "$ID_TOKEN" ]; then
+            echo "::error::Failed to mint identity token impersonating $SMOKE_SA. Check roles/iam.serviceAccountOpenIdTokenCreator on the invoker SA."
+            exit 1
+          fi
           echo "::add-mask::$ID_TOKEN"
           echo "Resolved $SERVICE -> $SERVICE_URL (invoker: $SMOKE_SA)"
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,121 @@
+name: Smoke
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'GitHub Environment (dev, stage) for vars/secrets and the deployed target'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  smoke:
+    name: Smoke Tests (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 10  # Typical run: 2-3 min (deps + 4 live HTTP checks). 10 min prevents hanging
+    env:
+      # Resolved once here, referenced via ${{ env.X }} below (self-documents the source).
+      ENV: ${{ inputs.environment }}
+      IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+      REGION: ${{ vars.REGION }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras --locked
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Resolve deployed service URL and invoker token
+        id: target
+        run: |
+          set -euo pipefail
+          SERVICE="${IMAGE_NAME}-${ENV}"
+
+          # Service naming is ${agent_name}-${environment}; agent_name == vars.IMAGE_NAME.
+          SERVICE_URL=$(gcloud run services describe "$SERVICE" \
+            --region "$REGION" \
+            --format='value(urls[0])')
+          if [ -z "$SERVICE_URL" ]; then
+            echo "::error::No serving URL for $SERVICE in $REGION — the revision did not deploy"
+            exit 1
+          fi
+
+          # Resolve the invoker SA by display name (decoupled from the 30-char account_id truncation).
+          SMOKE_SA=$(gcloud iam service-accounts list \
+            --filter="displayName='${SERVICE} Smoke Invoker'" \
+            --format='value(email)')
+          if [ -z "$SMOKE_SA" ]; then
+            echo "::error::No smoke invoker SA found for $SERVICE"
+            exit 1
+          fi
+
+          # Mint a Cloud Run ID token by impersonating the invoker SA (audience = service URL).
+          ID_TOKEN=$(gcloud auth print-identity-token \
+            --impersonate-service-account="$SMOKE_SA" \
+            --audiences="$SERVICE_URL")
+
+          echo "service_url=$SERVICE_URL" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$ID_TOKEN"
+          echo "id_token=$ID_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "Resolved $SERVICE -> $SERVICE_URL (invoker: $SMOKE_SA)"
+
+      - name: Run smoke tests
+        id: smoke
+        shell: bash {0}  # Removes -e flag to allow capturing output on failure
+        env:
+          SMOKE_BASE_URL: ${{ steps.target.outputs.service_url }}
+          SMOKE_ID_TOKEN: ${{ steps.target.outputs.id_token }}
+        run: |
+          OUTPUT_FILE=$(mktemp)
+
+          # Stream to logs (real-time) and a file (for the summary), capturing pytest's exit code.
+          uv run pytest tests/smoke 2>&1 | tee "$OUTPUT_FILE"
+          EXIT_CODE=${PIPESTATUS[0]}  # pytest's exit code, not tee's
+
+          {
+            echo "## 🔥 Smoke Tests (${ENV})"
+            echo ""
+            echo "Target: \`${SMOKE_BASE_URL}\`"
+            echo ""
+            if [ "$EXIT_CODE" -eq 0 ]; then
+              echo "✅ All smoke checks passed against the deployed revision."
+            else
+              echo "❌ Smoke checks failed (exit ${EXIT_CODE}) — the revision is not serving correctly."
+            fi
+            echo ""
+            echo '<details><summary>pytest output</summary>'
+            echo ""
+            echo '```'
+            cat "$OUTPUT_FILE"
+            echo '```'
+            echo ""
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          rm -f "$OUTPUT_FILE"
+          exit $EXIT_CODE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,10 +138,12 @@ uv run ruff format && uv run ruff check --fix && uv run mypy && uv run pytest --
 |---|---|---|---|
 | `tests/unit` | in-process only (mocks at boundaries) | yes | `uv run pytest` (default) |
 | `tests/integration` | real external resource (Postgres) | yes | `uv run pytest tests/integration` |
-| `tests/smoke` | live deployed URL | yes | `uv run pytest tests/smoke` |
+| `tests/smoke` | live deployed URL | assertion yes; generation no | `uv run pytest tests/smoke` |
 | `eval/` (top-level) | real LLM + Vertex AI creds (costs money) | gate metrics yes; judge metrics no | `uv run pytest eval` |
 
 **Eval lane:** Gate-fidelity runner is pytest calling `AgentEvaluator.evaluate()` (raises on sub-threshold metrics); `adk eval` CLI exits 0 on failed cases — authoring only, NEVER a CI gate. Deterministic PR-gate criteria (`tool_trajectory_avg_score` IN_ORDER 1.0, `response_match_score` ROUGE-1) in `eval/data/test_config.json`; judge metrics in `full_eval_config.json` (104-B/local only). The lane lives in top-level `eval/` (the test module loads the real `.env`), so `tests/conftest.py` mocks auth/dotenv unconditionally. Lane deps come from the `google-adk[eval]` extra in the dev group. **Not runnable as an autonomous sandboxed action** — the command sandbox blocks the Vertex AI egress and ADC credential read it needs; run it in CI or a developer's own terminal, never by widening the sandbox. Eval artifacts (`eval/data/`) are schema-validated on every PR by `tests/unit/test_eval_artifacts.py`. Cross-session memory (`load_memory`/`add_session_to_memory`) is NOT eval-testable (fresh session per case) — cover that continuity in the integration lane. Deliberately ADK-native (not the `agents-cli`/Agent Platform Eval SDK); regression-diff and failure-clustering live there, out of scope here. Full surface (`.test.json`, multi-turn, judge/rubric/safety metrics, user simulation, all `adk` commands): `docs/references/agent-evals.md`.
+
+**Smoke lane:** Runs POST-DEPLOY from `ci-cd.yml` (reusable `.github/workflows/smoke.yml`) after each env apply — dev in dev-only mode, dev+stage in production mode — NOT in `ci.yml`. Layered cheapest-first against the live revision (L0 `/health`, L1 session-create → Cloud SQL reachability, L2 thin `/run_sse` turn asserting presence of a text part only, then delete-and-404 cleanup). L2 invokes the real model but the assertion is presence-only (no content, no judge). Auth: the WIF principal impersonates a dedicated invoker SA (`terraform/main/smoke.tf`) to mint a Cloud Run ID token; smoke.yml resolves the service URL and that SA's email (by display name), exporting `SMOKE_BASE_URL`/`SMOKE_ID_TOKEN` to the test step. CI-only — fixtures fail clearly if those env vars are unset.
 
 **pytest_configure()** - Only place using unittest.mock (runs before pytest-mock available). Mocks `dotenv.load_dotenv` and Google auth defaults to prevent real credential lookups during collection. See `tests/conftest.py` for the current mock set and the lifecycle docstring.
 - No env var assignments needed (PEP 562 lazy loading, Pydantic validates only when called)
@@ -219,6 +221,7 @@ uv lock --upgrade               # Update all
 
 **Main Module (Template Internals except `services.tf`/`iam.tf`):** Cloud Run deployment in `terraform/main/` (may require downstream env var customization or extension). Provisions VPC + Cloud SQL private IP, bastion, app SA, Cloud Run with Auth Proxy sidecar, Agent Engine, and GCS bucket. See `terraform/main/` for resource definitions.
 - Shared `local.cloud_sql_proxy_args` between bastion cloud-init and Cloud Run sidecar (bastion adds `--address=0.0.0.0`, `--impersonate-service-account`, COS iptables rule)
+- `smoke.tf` — post-deploy smoke-test identity (dedicated invoker SA, service-level `roles/run.invoker`, WIF `serviceAccountOpenIdTokenCreator`); consumed by `.github/workflows/smoke.yml`
 - Remote state in GCS; inputs from `TF_VAR_*` (GitHub Environment variables)
 - Requires `TF_VAR_environment` (dev/stage/prod)
 - Outputs: `bastion_instance`, `bastion_zone` (for docker-compose `.env`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Post-deploy smoke test lane (`tests/smoke/`): hits the live Cloud Run service URL after each environment apply to confirm a freshly deployed revision actually serves end to end. Layered cheapest-first so a failure localizes the broken subsystem: L0 `GET /health` -> 200 (the revision serves HTTP at all), L1 session create + read-back -> 200 (Cloud SQL is reachable through the Auth Proxy sidecar over VPC egress, no model), L2 a thin `/run_sse` agent turn that parses the SSE stream and asserts at least one event carries a text part (presence only, never content, so no LLM-judge dependency), then cleanup deletes the smoke session and a follow-up GET returns 404. Drives the live URL over a real network with an authenticated httpx client reading `SMOKE_BASE_URL` and `SMOKE_ID_TOKEN`; runs only by explicit path (`uv run pytest tests/smoke`), never under a bare `pytest`. New `smoke.yml` reusable workflow resolves the service URL with `gcloud run services describe`, mints a Cloud Run ID token by impersonating a dedicated invoker SA, runs the lane, and surfaces pass/fail in the job summary; `ci-cd.yml` runs `smoke-dev` after `dev-apply` (and `smoke-stage` after `stage-apply` in production mode). Runs post-deploy, not in the PR gate (#101)
+- Dedicated smoke invoker service account (`terraform/main/smoke.tf`): a least-privilege identity distinct from the runtime app SA, granted `roles/run.invoker` at the Cloud Run service resource (not project-wide), with the GitHub Actions WIF principal granted `roles/iam.serviceAccountOpenIdTokenCreator` on it so the runner can mint a Cloud Run ID token by impersonation. The service deploys `--no-allow-unauthenticated`, so requests need an identity token, and a raw WIF principal cannot mint one directly. A `time_sleep` mirrors the `iam.tf` propagation-wait pattern so a first apply does not race the binding (#101)
+
 ## [0.18.0] - 2026-06-15
 
 ### Added

--- a/docs/references/cicd.md
+++ b/docs/references/cicd.md
@@ -14,6 +14,7 @@ GitHub Actions workflow architecture, mechanics, and customization.
 - **`pull-and-promote.yml`** - Image promotion between registries (production mode)
 - **`resolve-image-digest.yml`** - Digest lookup by tag (production mode)
 - **`terraform-plan-apply.yml`** - Terraform deployment
+- **`smoke.yml`** - Post-deploy smoke tests against the live deployed revision
 
 **Standalone CI Workflow:**
 - **`ci.yml`** - Code quality (ruff, mypy, pytest with coverage), Postgres integration lane, and deterministic agent eval gate
@@ -56,7 +57,9 @@ GitHub Actions workflow architecture, mechanics, and customization.
 - `build` - Build Docker image (branch events only, not tags)
 - `resolve-digest` - Look up image in stage by tag (tag events in production mode)
 - `dev-plan` / `dev-apply` - Dev environment (branch events)
+- `smoke-dev` - Post-deploy smoke against the live dev revision (after `dev-apply`)
 - `stage-promote` / `stage-plan` / `stage-apply` - Stage environment (merge in production mode)
+- `smoke-stage` - Post-deploy smoke against the live stage revision (after `stage-apply`, production mode only)
 - `prod-promote` / `prod-plan` / `prod-apply` - Prod environment (tags in production mode)
 
 **Concurrency:**
@@ -109,28 +112,32 @@ config → metadata-extract → docker-build → dev-plan
 
 **Dev-only mode:**
 ```
-config → metadata-extract → docker-build → dev-plan → dev-apply
+config → metadata-extract → docker-build → dev-plan → dev-apply → smoke-dev
                               ↓
                            Push to dev registry: {sha}, latest
                               ↓
                            Deploy to dev Cloud Run
+                              ↓
+                           Smoke the live dev revision
 ```
 
 **Production mode:**
 ```
 config → metadata-extract → docker-build
            ↓                    ↓
-           └────────────────────┴─→ dev-plan → dev-apply
+           └────────────────────┴─→ dev-plan → dev-apply → smoke-dev
                                     (parallel)
                                 ↓
-                              stage-promote → stage-plan → stage-apply
+                              stage-promote → stage-plan → stage-apply → smoke-stage
                                 ↓
                            Pull from dev, push to stage
                                 ↓
                            Deploy to stage Cloud Run
+                                ↓
+                           Smoke the live stage revision
 ```
 
-**Result:** Dev deployed (always), stage deployed (production mode only).
+**Result:** Dev deployed and smoked (always), stage deployed and smoked (production mode only). The smoke lane detail lives in [Testing Strategy](testing.md).
 
 ### Tag Flow
 
@@ -293,6 +300,23 @@ config → metadata-extract → resolve-digest → prod-promote → prod-plan �
 - `plan` job on PR: Comment plan, don't save artifact
 - `plan` job on merge: Save plan artifact (no comment)
 - `apply` job: Use saved plan artifact
+
+### smoke.yml
+
+**Purpose:** Run the post-deploy smoke lane against the live deployed Cloud Run revision.
+
+**Inputs:**
+- `environment` (dev/stage) - selects the GitHub Environment vars and the deployed target
+
+**How it works:**
+1. Authenticate to GCP via WIF
+2. Resolve the service URL with `gcloud run services describe`
+3. Resolve the dedicated invoker SA by display name and mint a Cloud Run ID token by impersonating it (`gcloud auth print-identity-token --impersonate-service-account --audiences`)
+4. Run `uv run pytest tests/smoke` with `SMOKE_BASE_URL` and `SMOKE_ID_TOKEN` set, surfacing pass/fail in the job summary
+
+The service deploys `--no-allow-unauthenticated`, so requests need a Cloud Run identity token. The invoker SA is a least-privilege identity distinct from the runtime app SA. See [Security Posture](security-posture.md) for the identity model. The lane layering and assertions live in [Testing Strategy](testing.md).
+
+**When it runs:** Called by `ci-cd.yml` as `smoke-dev` after `dev-apply` (and `smoke-stage` after `stage-apply` in production mode), on branch push events only. Not part of the PR gate.
 
 ## Standalone CI Workflow
 

--- a/docs/references/security-posture.md
+++ b/docs/references/security-posture.md
@@ -45,9 +45,12 @@ The project enforces security at every layer of the stack, from network topology
 
 **Cross-project promotion uses WIF principals, not service accounts.** Stage reads from dev's Artifact Registry, prod reads from stage's — but the IAM binding uses the WIF pool principal, not a service account. This avoids org policies that restrict cross-project service account usage and keeps the trust boundary at the identity pool level.
 
+**Dedicated smoke invoker, scoped to one service.** The post-deploy smoke lane calls the live Cloud Run revision, which deploys `--no-allow-unauthenticated` and so requires a Cloud Run identity token. Rather than reuse the runtime app SA, the template provisions a separate invoker service account whose only grant is `roles/run.invoker` on the app Cloud Run service resource, not project-wide, so it can call that one service and nothing else. The GitHub Actions WIF principal is granted `roles/iam.serviceAccountOpenIdTokenCreator` on the invoker SA so CI can mint an ID token by impersonation; a raw federated principal cannot mint one directly. ID tokens authenticate to Cloud Run, so this is the OpenID token-creator role, not the access-token `serviceAccountTokenCreator`. Smoke access lives on its own identity, scoped to invocation and auditable independently of the runtime SA.
+
 - Source: `terraform/bootstrap/module/gcp/main.tf` (WIF pool, provider, attribute conditions)
 - Source: `terraform/main/database.tf` (IAM database user, password policy)
-- GCP docs: [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation), [IAM database authentication](https://cloud.google.com/sql/docs/postgres/iam-authentication)
+- Source: `terraform/main/smoke.tf` (smoke invoker SA, resource-scoped `run.invoker`, WIF token-creator grant)
+- GCP docs: [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation), [IAM database authentication](https://cloud.google.com/sql/docs/postgres/iam-authentication), [Cloud Run authentication](https://cloud.google.com/run/docs/authenticating/service-to-service)
 - Guide: [Infrastructure](../infrastructure.md), Reference: [Bootstrap](bootstrap.md)
 
 ## Database Layer

--- a/docs/references/testing.md
+++ b/docs/references/testing.md
@@ -53,6 +53,40 @@ The connection defaults to `postgresql+asyncpg://postgres:postgres@127.0.0.1:543
 
 The `ci.yml` `integration` job runs a `postgres:17` service container (with a `pg_isready` health check) and sets `INTEGRATION_DATABASE_URI` to reach it. It is gated on the `changes` job and folded into the always-runs `status` sentinel, so the single required check `CI / status` covers it. The job runs `uv run pytest tests/integration` without `--cov` — the 100% coverage gate is unit-lane-only.
 
+## Smoke Lane
+
+The smoke lane (`tests/smoke/`) hits the live deployed Cloud Run service URL after each environment apply to confirm a freshly deployed revision actually serves end to end. Unlike the integration lane, which builds the app in-process via httpx `ASGITransport`, nothing here is substituted: the request crosses the real network, the Auth Proxy sidecar, and Cloud SQL. The L2 turn invokes the real model, but the lane is still a deterministic gate. Behavioral correctness stays owned by the eval lane, pre-deploy wiring by the integration lane.
+
+### What each layer catches
+
+Checks run cheapest-first, each a distinct failure class so a failure localizes the broken subsystem:
+
+- **L0 liveness**: `GET /health` -> 200. The revision serves HTTP at all.
+- **L1 session create**: create a session, read it back -> 200. Cloud SQL is reachable through the Auth Proxy sidecar over VPC egress, and a session row persists. Deterministic, no model. A module-scoped fixture owns the create so teardown deletes the row unconditionally even when a later check fails.
+- **L2 thin agent turn**: `POST /run_sse` with a trivial prompt, parse the SSE event stream, and assert at least one event carries a text part. The real model is invoked, but the assertion checks only that a text part returned, never what it says, so the check is robust to the model's stochastic output and carries no LLM-judge dependency.
+- **Cleanup**: delete the smoke session, then a follow-up GET returns 404. Proves the delete path and leaves no residue.
+
+### Run it locally
+
+The lane targets a live deployed URL with an authenticated client, so it reads two env vars and fails clearly if either is unset:
+
+```bash
+SMOKE_BASE_URL="https://your-agent-dev-...run.app" \
+SMOKE_ID_TOKEN="$(gcloud auth print-identity-token \
+  --impersonate-service-account=SMOKE_INVOKER_SA \
+  --audiences=https://your-agent-dev-...run.app)" \
+  uv run pytest tests/smoke
+```
+
+- `SMOKE_BASE_URL`: the deployed service URL (the httpx `base_url`).
+- `SMOKE_ID_TOKEN`: a Cloud Run ID token, sent as `Authorization: Bearer`.
+
+Both are test-harness variables, not application runtime config, so they live here rather than in `docs/environment-variables.md`. A bare `uv run pytest` never collects this lane; select it explicitly with `uv run pytest tests/smoke`.
+
+### How CI runs it post-deploy
+
+The `smoke.yml` reusable workflow resolves the service URL with `gcloud run services describe`, resolves the dedicated invoker SA by display name, mints a Cloud Run ID token by impersonating it (`gcloud auth print-identity-token --impersonate-service-account --audiences`), runs the lane, and surfaces pass/fail in the GitHub job summary. The service deploys `--no-allow-unauthenticated`, so requests need an identity token; Cloud Run authorizes the token identity, the invoker SA. The `ci-cd.yml` orchestrator calls it as `smoke-dev` after `dev-apply` (and `smoke-stage` after `stage-apply` in production mode). This runs post-deploy against the live revision, not in the PR gate. The invoker identity and its least-privilege scoping are documented in [Security Posture](security-posture.md).
+
 ## Coverage Requirements
 
 **100% coverage required on production code.**

--- a/terraform/main/smoke.tf
+++ b/terraform/main/smoke.tf
@@ -41,6 +41,19 @@ resource "google_service_account_iam_member" "smoke_token_creator" {
   member             = var.workload_identity_pool_principal_identifier
 }
 
+# GCP SA-level IAM is eventually consistent. On a first apply (or SA replace) the
+# token-mint impersonation can fail before this binding propagates, surfacing as a
+# false-negative smoke result. Gate apply completion on a short propagation wait,
+# mirroring time_sleep.wif_iam_propagation in iam.tf. The trigger on the binding id
+# fires this only on create/replace; steady-state applies don't re-wait.
+resource "time_sleep" "smoke_token_creator_propagation" {
+  create_duration = "60s"
+
+  triggers = {
+    iam_member_id = google_service_account_iam_member.smoke_token_creator.id
+  }
+}
+
 output "smoke_invoker_service_account_email" {
   description = "Email of the SA the CI smoke lane impersonates to invoke Cloud Run"
   value       = google_service_account.smoke_invoker.email

--- a/terraform/main/smoke.tf
+++ b/terraform/main/smoke.tf
@@ -1,0 +1,47 @@
+# Post-deploy smoke-test identity. The smoke lane (.github/workflows/smoke.yml)
+# hits the live Cloud Run revision after each env apply. The GitHub Actions WIF
+# principal impersonates this dedicated invoker SA to mint a Cloud Run ID token,
+# rather than reusing the runtime app SA, so smoke access is scoped and auditable
+# on its own identity.
+
+locals {
+  # Service account IDs — GCP 30-char limit. Mirror main.tf's truncation: keep the
+  # environment suffix intact, truncate the agent_name prefix to fit.
+  sa_suffix_smoke = "-smoke-${var.environment}"
+  sa_prefix_smoke = substr(var.agent_name, 0, local.sa_limit - length(local.sa_suffix_smoke))
+  sa_id_smoke     = "${local.sa_prefix_smoke}${local.sa_suffix_smoke}"
+}
+
+resource "google_service_account" "smoke_invoker" {
+  account_id = local.sa_id_smoke
+  # smoke.yml resolves this SA's email by display name (decoupling from the 30-char
+  # account_id truncation), so keep the display name stable.
+  display_name = "${local.resource_name} Smoke Invoker"
+  description  = "Identity impersonated by CI to invoke the ${local.resource_name} Cloud Run service for post-deploy smoke tests"
+}
+
+# Grant the invoke role at the service resource level (not project-wide) so this
+# identity can call only the app service. for_each over the same locations as the
+# Cloud Run service so the binding tracks every deployed location.
+resource "google_cloud_run_v2_service_iam_member" "smoke_invoker" {
+  for_each = local.locations
+  project  = google_cloud_run_v2_service.app[each.key].project
+  location = google_cloud_run_v2_service.app[each.key].location
+  name     = google_cloud_run_v2_service.app[each.key].name
+  role     = "roles/run.invoker"
+  member   = google_service_account.smoke_invoker.member
+}
+
+# Let the WIF principal mint ID tokens as the invoker SA. ID tokens (not access
+# tokens) authenticate to Cloud Run, so this is serviceAccountOpenIdTokenCreator,
+# not serviceAccountTokenCreator.
+resource "google_service_account_iam_member" "smoke_token_creator" {
+  service_account_id = google_service_account.smoke_invoker.name
+  role               = "roles/iam.serviceAccountOpenIdTokenCreator"
+  member             = var.workload_identity_pool_principal_identifier
+}
+
+output "smoke_invoker_service_account_email" {
+  description = "Email of the SA the CI smoke lane impersonates to invoke Cloud Run"
+  value       = google_service_account.smoke_invoker.email
+}

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -35,12 +35,9 @@ APP_NAME = "agent_foundation"
 
 USER_ID = "smoke-user"
 
-# Declare the lane contract for the whole directory so any future smoke module
-# inherits the marker (kept out of a bare `pytest`) and the session-scoped loop.
-pytestmark = [
-    pytest.mark.smoke,
-    pytest.mark.asyncio(loop_scope="session"),
-]
+# A conftest `pytestmark` does not propagate to sibling test modules: each smoke test
+# module declares its own `pytestmark` (smoke marker + session loop scope, see
+# test_smoke.py) so it is selected under the lane and shares the client's event loop.
 
 
 @pytest.fixture(scope="session")

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1,0 +1,90 @@
+"""Fixtures for the smoke lane (real HTTP against a live deployed revision).
+
+This lane verifies a freshly deployed Cloud Run revision actually serves: it drives
+the live service URL over a real network with an authenticated httpx client. Unlike
+the integration lane (which builds the app in-process via ASGI), nothing here is
+substituted — the request crosses the network, the Auth Proxy sidecar, and Cloud SQL.
+The L2 turn invokes the real model; the lane asserts only that a text part returned
+(presence, never content), so it carries no LLM-judge dependency.
+
+Runs only in CI after a deploy, where ``smoke.yml`` resolves the service URL and mints
+a Cloud Run identity token impersonating the dedicated invoker SA, exporting both as
+env vars:
+
+- ``SMOKE_BASE_URL`` — the deployed service URL (the httpx ``base_url``).
+- ``SMOKE_ID_TOKEN`` — a Cloud Run ID token (sent as ``Authorization: Bearer``).
+
+Both are required; the fixtures fail clearly if either is unset, since this lane has
+no meaning without a live target. A bare ``uv run pytest`` never collects it
+(``testpaths`` is the unit lane); select it explicitly with ``uv run pytest
+tests/smoke``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+# ADK app name — the agent package directory discovered under src/
+# (src/agent_foundation -> "agent_foundation").
+APP_NAME = "agent_foundation"
+
+USER_ID = "smoke-user"
+
+pytestmark = [
+    pytest.mark.smoke,
+    # The client fixture is session-scoped (one connection per run); its async setup
+    # and these tests must share one event loop.
+    pytest.mark.asyncio(loop_scope="session"),
+]
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Live service URL, required from the environment."""
+    url = os.environ.get("SMOKE_BASE_URL")
+    if not url:
+        pytest.fail(
+            "SMOKE_BASE_URL is unset. The smoke lane targets a live deployed URL and "
+            "only runs in CI after a deploy (see .github/workflows/smoke.yml)."
+        )
+    return url
+
+
+@pytest.fixture(scope="session")
+def id_token() -> str:
+    """Cloud Run identity token, required from the environment."""
+    token = os.environ.get("SMOKE_ID_TOKEN")
+    if not token:
+        pytest.fail(
+            "SMOKE_ID_TOKEN is unset. The smoke lane needs a Cloud Run ID token minted "
+            "by impersonating the invoker SA (see .github/workflows/smoke.yml)."
+        )
+    return token
+
+
+@pytest.fixture(scope="session")
+def app_name() -> str:
+    """ADK app name (the agent package directory discovered under src/)."""
+    return APP_NAME
+
+
+@pytest.fixture(scope="session")
+def user_id() -> str:
+    """Synthetic user id for smoke session rows."""
+    return USER_ID
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def client(base_url: str, id_token: str) -> AsyncIterator[AsyncClient]:
+    """Authenticated httpx client over a real network to the live service."""
+    async with AsyncClient(
+        base_url=base_url,
+        headers={"Authorization": f"Bearer {id_token}"},
+        timeout=30.0,
+    ) as c:
+        yield c

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -35,6 +35,13 @@ APP_NAME = "agent_foundation"
 
 USER_ID = "smoke-user"
 
+# Declare the lane contract for the whole directory so any future smoke module
+# inherits the marker (kept out of a bare `pytest`) and the session-scoped loop.
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.asyncio(loop_scope="session"),
+]
+
 
 @pytest.fixture(scope="session")
 def base_url() -> str:

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -35,13 +35,6 @@ APP_NAME = "agent_foundation"
 
 USER_ID = "smoke-user"
 
-pytestmark = [
-    pytest.mark.smoke,
-    # The client fixture is session-scoped (one connection per run); its async setup
-    # and these tests must share one event loop.
-    pytest.mark.asyncio(loop_scope="session"),
-]
-
 
 @pytest.fixture(scope="session")
 def base_url() -> str:

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -5,55 +5,76 @@ broken subsystem:
 
 - L0 liveness: the revision serves HTTP at all (``/health`` -> 200).
 - L1 session create: Cloud SQL is reachable via the Auth Proxy sidecar (a session row
-  persists). Deterministic, no model.
+  persists). Deterministic, no model. Provided as a module-scoped fixture so its
+  teardown deletes the row unconditionally even if a later check fails.
 - L2 thin agent turn: the run path streams a model response (``/run_sse``). The real
   model is invoked, but the assertion is presence-only — at least one event carries a
   text part — never content, so there is no LLM-judge dependency.
 - Cleanup: the smoke session is deleted and a follow-up GET returns 404, proving the
   delete path and leaving no residue.
 
-Every test is marked ``smoke`` (lane conftest) and runs only by explicit path
+Every test is marked ``smoke`` (module ``pytestmark``) and runs only by explicit path
 (``uv run pytest tests/smoke``) against ``SMOKE_BASE_URL`` with ``SMOKE_ID_TOKEN``.
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
 
+import pytest
+import pytest_asyncio
 from httpx import AsyncClient
+
+pytestmark = [
+    pytest.mark.smoke,
+    # The client fixture is session-scoped (one connection per run); its async setup
+    # and these tests must share one event loop.
+    pytest.mark.asyncio(loop_scope="session"),
+]
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def smoke_session_id(
+    client: AsyncClient, app_name: str, user_id: str
+) -> AsyncIterator[str]:
+    """Create a session, yield its id, and delete it unconditionally on teardown.
+
+    Proves Cloud SQL reachability via the Auth Proxy sidecar on setup. Owning the
+    delete in teardown (rather than a trailing test method) guarantees the row is
+    cleaned up even when a downstream check fails or the run aborts under ``-x``.
+    """
+    resp = await client.post(
+        f"/apps/{app_name}/users/{user_id}/sessions",
+        json={"state": {}},
+    )
+    assert resp.status_code == 200
+    session_id = resp.json()["id"]
+    assert session_id
+    try:
+        yield session_id
+    finally:
+        await client.delete(f"/apps/{app_name}/users/{user_id}/sessions/{session_id}")
 
 
 class TestSmoke:
-    """Ordered, layered checks sharing one smoke session for guaranteed cleanup.
-
-    The session id is stashed on the class by the create check and consumed by the
-    later checks, so the layers run cheapest-first and the cleanup check always has the
-    id it needs to delete. pytest runs tests in declaration order within a class, so the
-    L0 -> L1 -> L2 -> cleanup sequence holds without an ordering plugin.
-    """
-
-    session_id: str
+    """Layered checks sharing one smoke session whose cleanup is fixture-guaranteed."""
 
     async def test_l0_health_liveness(self, client: AsyncClient) -> None:
         """L0: the deployed revision answers the liveness probe."""
         resp = await client.get("/health")
         assert resp.status_code == 200
 
-    async def test_l1_session_create(
-        self, client: AsyncClient, app_name: str, user_id: str
-    ) -> None:
+    async def test_l1_session_create(self, smoke_session_id: str) -> None:
         """L1: a session persists, proving Cloud SQL reachability via Auth Proxy."""
-        resp = await client.post(
-            f"/apps/{app_name}/users/{user_id}/sessions",
-            json={"state": {}},
-        )
-        assert resp.status_code == 200
-        session_id = resp.json()["id"]
-        assert session_id
-        TestSmoke.session_id = session_id
+        assert smoke_session_id
 
     async def test_l2_agent_turn_streams_text(
-        self, client: AsyncClient, app_name: str, user_id: str
+        self,
+        client: AsyncClient,
+        app_name: str,
+        user_id: str,
+        smoke_session_id: str,
     ) -> None:
         """L2: the run path streams at least one text-bearing event.
 
@@ -63,14 +84,16 @@ class TestSmoke:
         body = {
             "app_name": app_name,
             "user_id": user_id,
-            "session_id": TestSmoke.session_id,
+            "session_id": smoke_session_id,
             "new_message": {"role": "user", "parts": [{"text": "Hi!"}]},
             "streaming": True,
         }
 
         saw_text = False
         async with client.stream("POST", "/run_sse", json=body) as resp:
-            assert resp.status_code == 200
+            if resp.status_code != 200:
+                detail = (await resp.aread()).decode(errors="replace")
+                pytest.fail(f"/run_sse returned {resp.status_code}: {detail}")
             async for line in resp.aiter_lines():
                 if not line.startswith("data:"):
                     continue
@@ -85,17 +108,24 @@ class TestSmoke:
 
         assert saw_text, "no text-bearing event in the /run_sse stream"
 
-    async def test_l3_cleanup_session_deleted(
-        self, client: AsyncClient, app_name: str, user_id: str
+    async def test_l3_session_delete_returns_404(
+        self,
+        client: AsyncClient,
+        app_name: str,
+        user_id: str,
+        smoke_session_id: str,
     ) -> None:
-        """Cleanup: the smoke session is deleted and a follow-up GET returns 404."""
-        session_id = TestSmoke.session_id
+        """Cleanup: deleting the smoke session makes a follow-up GET return 404.
+
+        Deletes here (proving the delete path) and the fixture teardown's idempotent
+        delete tolerates the already-removed row.
+        """
         delete = await client.delete(
-            f"/apps/{app_name}/users/{user_id}/sessions/{session_id}"
+            f"/apps/{app_name}/users/{user_id}/sessions/{smoke_session_id}"
         )
         assert delete.status_code == 200
 
         gone = await client.get(
-            f"/apps/{app_name}/users/{user_id}/sessions/{session_id}"
+            f"/apps/{app_name}/users/{user_id}/sessions/{smoke_session_id}"
         )
         assert gone.status_code == 404

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -1,0 +1,101 @@
+"""Post-deploy smoke checks against a live Cloud Run revision.
+
+Layered cheapest-first, each a distinct failure class so a failure localizes the
+broken subsystem:
+
+- L0 liveness: the revision serves HTTP at all (``/health`` -> 200).
+- L1 session create: Cloud SQL is reachable via the Auth Proxy sidecar (a session row
+  persists). Deterministic, no model.
+- L2 thin agent turn: the run path streams a model response (``/run_sse``). The real
+  model is invoked, but the assertion is presence-only — at least one event carries a
+  text part — never content, so there is no LLM-judge dependency.
+- Cleanup: the smoke session is deleted and a follow-up GET returns 404, proving the
+  delete path and leaving no residue.
+
+Every test is marked ``smoke`` (lane conftest) and runs only by explicit path
+(``uv run pytest tests/smoke``) against ``SMOKE_BASE_URL`` with ``SMOKE_ID_TOKEN``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from httpx import AsyncClient
+
+
+class TestSmoke:
+    """Ordered, layered checks sharing one smoke session for guaranteed cleanup.
+
+    The session id is stashed on the class by the create check and consumed by the
+    later checks, so the layers run cheapest-first and the cleanup check always has the
+    id it needs to delete. pytest runs tests in declaration order within a class, so the
+    L0 -> L1 -> L2 -> cleanup sequence holds without an ordering plugin.
+    """
+
+    session_id: str
+
+    async def test_l0_health_liveness(self, client: AsyncClient) -> None:
+        """L0: the deployed revision answers the liveness probe."""
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+
+    async def test_l1_session_create(
+        self, client: AsyncClient, app_name: str, user_id: str
+    ) -> None:
+        """L1: a session persists, proving Cloud SQL reachability via Auth Proxy."""
+        resp = await client.post(
+            f"/apps/{app_name}/users/{user_id}/sessions",
+            json={"state": {}},
+        )
+        assert resp.status_code == 200
+        session_id = resp.json()["id"]
+        assert session_id
+        TestSmoke.session_id = session_id
+
+    async def test_l2_agent_turn_streams_text(
+        self, client: AsyncClient, app_name: str, user_id: str
+    ) -> None:
+        """L2: the run path streams at least one text-bearing event.
+
+        Invokes the real model. Asserts presence of a text part only — never its
+        content — so the check is robust to the model's stochastic output.
+        """
+        body = {
+            "app_name": app_name,
+            "user_id": user_id,
+            "session_id": TestSmoke.session_id,
+            "new_message": {"role": "user", "parts": [{"text": "Hi!"}]},
+            "streaming": True,
+        }
+
+        saw_text = False
+        async with client.stream("POST", "/run_sse", json=body) as resp:
+            assert resp.status_code == 200
+            async for line in resp.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                payload = line.removeprefix("data:").strip()
+                if not payload:
+                    continue
+                event = json.loads(payload)
+                parts = event.get("content", {}).get("parts", [])
+                if any(isinstance(p.get("text"), str) and p["text"] for p in parts):
+                    saw_text = True
+                    break
+
+        assert saw_text, "no text-bearing event in the /run_sse stream"
+
+    async def test_l3_cleanup_session_deleted(
+        self, client: AsyncClient, app_name: str, user_id: str
+    ) -> None:
+        """Cleanup: the smoke session is deleted and a follow-up GET returns 404."""
+        session_id = TestSmoke.session_id
+        delete = await client.delete(
+            f"/apps/{app_name}/users/{user_id}/sessions/{session_id}"
+        )
+        assert delete.status_code == 200
+
+        gone = await client.get(
+            f"/apps/{app_name}/users/{user_id}/sessions/{session_id}"
+        )
+        assert gone.status_code == 404

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -65,9 +65,23 @@ class TestSmoke:
         resp = await client.get("/health")
         assert resp.status_code == 200
 
-    async def test_l1_session_create(self, smoke_session_id: str) -> None:
-        """L1: a session persists, proving Cloud SQL reachability via Auth Proxy."""
-        assert smoke_session_id
+    async def test_l1_session_create(
+        self,
+        client: AsyncClient,
+        app_name: str,
+        user_id: str,
+        smoke_session_id: str,
+    ) -> None:
+        """L1: the created session is readable back, proving Cloud SQL reachability.
+
+        GETs the session the fixture created so the round-trip is an independent
+        signal distinct from the fixture's create-time assertion.
+        """
+        resp = await client.get(
+            f"/apps/{app_name}/users/{user_id}/sessions/{smoke_session_id}"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == smoke_session_id
 
     async def test_l2_agent_turn_streams_text(
         self,

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -109,7 +109,11 @@ class TestSmoke:
                 detail = (await resp.aread()).decode(errors="replace")
                 pytest.fail(f"/run_sse returned {resp.status_code}: {detail}")
             async for line in resp.aiter_lines():
-                if not line.startswith("data:"):
+                # Keep draining once a text part is seen rather than breaking early:
+                # closing the stream mid-flight makes Cloud Run log a spurious client
+                # disconnect on every run, eroding the post-deploy log signal. The
+                # trivial prompt's response is small, so draining is cheap.
+                if saw_text or not line.startswith("data:"):
                     continue
                 payload = line.removeprefix("data:").strip()
                 if not payload:
@@ -118,7 +122,6 @@ class TestSmoke:
                 parts = event.get("content", {}).get("parts", [])
                 if any(isinstance(p.get("text"), str) and p["text"] for p in parts):
                     saw_text = True
-                    break
 
         assert saw_text, "no text-bearing event in the /run_sse stream"
 


### PR DESCRIPTION
## What

Add a post-deploy end-to-end smoke lane that hits the live Cloud Run service URL after each environment apply, confirming a freshly deployed revision actually serves real requests end to end. Thin but broad: it exercises the real serving path (HTTP, Cloud SQL over VPC egress, model wiring) without asserting anything about model output.

## Why

The integration lane (#102) proves the pieces fit pre-deploy against a local Postgres. Smoke proves the deployed revision is actually up and serving in each environment. It catches deploy-time failures no pre-deploy test can: bad VPC egress, a broken Auth Proxy sidecar, or a revision that boots but cannot reach the session DB.

## How

- `tests/smoke/`: a pytest lane over a real authenticated httpx client against the live URL. Layered cheapest-first so a failure localizes the broken subsystem: L0 `GET /health` (liveness), L1 session create plus read-back (Cloud SQL reachability through the Auth Proxy sidecar, no model), L2 a thin `/run_sse` agent turn that parses the SSE stream and asserts at least one event carries a text part (presence only, never content, so no LLM-judge dependency), then cleanup deletes the session and a follow-up GET returns 404. Reads `SMOKE_BASE_URL` and `SMOKE_ID_TOKEN`; never collected by a bare `pytest`.
- `.github/workflows/smoke.yml`: reusable workflow that authenticates via WIF, resolves the service URL with `gcloud run services describe`, mints a Cloud Run ID token by impersonating a dedicated invoker SA, runs the lane, and surfaces pass/fail in the job summary.
- `.github/workflows/ci-cd.yml`: `smoke-dev` runs after `dev-apply`; `smoke-stage` runs after `stage-apply` in production mode. Dev-only mode smokes dev; production mode smokes dev and stage.
- `terraform/main/smoke.tf`: a dedicated invoker service account distinct from the runtime app SA, granted `roles/run.invoker` at the Cloud Run service resource (not project-wide), with the WIF principal granted `roles/iam.serviceAccountOpenIdTokenCreator` on it so CI can mint an ID token by impersonation. A `time_sleep` mirrors the `iam.tf` propagation-wait so a first apply does not race the binding.
- Docs: `docs/references/testing.md` (smoke lane section), `docs/references/cicd.md` (post-deploy step and flow diagrams), `docs/references/security-posture.md` (invoker identity), `AGENTS.md` (lane-table nuance and smoke prose), and a CHANGELOG `[Unreleased]` entry.

## Design notes

L2 invokes the real model but is still a deterministic gate: it asserts a text part came back, not what the text says. Invoking the model is not judging it. Behavioral correctness stays owned by the eval suite (#104), pre-deploy wiring by the integration tests (#102).

Auth uses impersonation because Cloud Run authorizes the token identity (the invoker SA), so the WIF principal's own roles are irrelevant to invocation. ID-token minting specifically needs `serviceAccountOpenIdTokenCreator`, not the access-token `serviceAccountTokenCreator`.

## Tests

- [x] Quality gate green on the committed tree: `ruff format --check`, `ruff check`, `mypy`, `pytest --cov` (76 passed, 100% coverage).
- [x] `terraform fmt -check -recursive terraform/main` clean.
- [ ] Smoke lane itself runs post-deploy, not in the PR gate (it needs a live URL). It first executes against the dev revision on the post-merge `ci-cd.yml` deploy. Watch `Smoke Dev` in that run.

## Deferred findings

The adversarial review surfaced one medium left for a follow-up: the L1 assertion lives in a module-scoped fixture (a Cloud SQL outage reports as `ERROR` rather than `FAILED`) and the AC5 404 verification lives in the trailing `test_l3`, so under `-x` after an L2 failure that specific assertion is skipped. The session delete itself still runs unconditionally in fixture teardown, and CI runs the lane without `-x`, so cleanup and the 404 check both execute on every CI run. Restructuring to assert the 404 inside the fixture teardown is a clean refinement but not required for correctness.

## Related Issues

Closes #101
