### PR TITLE
chore: enable pytest importlib import mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit, integration, and eval lanes resolve the agent package name from `src/` at import time instead of hard-coding it, so a downstream fork that renames the package reuses every lane (and the eval gate) with no edits. The unit `conftest.py` builds its mock patch targets from the discovered name, so `init_template.py` no longer rewrites it and template syncs diff it clean
 - Restructured `docs/references/testing.md` into the lane taxonomy plus the unit-test guide, splitting the integration lane into its own `docs/references/integration-tests.md` (added to the docs indexes and MkDocs nav); non-unit lanes now point to their own reference docs
 - Integration test lane and the `ci.yml` `integration` job now run against a `postgres:18` service container, matching the deployed `POSTGRES_18` Cloud SQL major version (previously `postgres:17`)
+- pytest now runs with `--import-mode=importlib` (pytest's recommended import mode for new projects), which keeps test directories free of `__init__.py` and avoids same-named modules colliding across lanes. Lane selection stays by explicit path; the registered `integration`/`smoke` markers are kept for ad-hoc `-m` selection (e.g. `-m "not integration"`)
 
 ### Fixed
 - `docs/references/agent-evals.md` is now listed in the MkDocs site nav (previously reachable only through the docs index pages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ directory = "htmlcov"
 # https://docs.pytest.org/en/stable/explanation/goodpractices.html
 addopts = "--import-mode=importlib"
 # Bare `pytest` runs only the fast, deterministic unit lane; other lanes run by
-# explicit path (e.g. `pytest tests/integration`) — see AGENTS.md Testing Patterns
+# explicit path (e.g. `uv run pytest tests/integration`) — see AGENTS.md Testing Patterns
 testpaths = ["tests/unit"]
 # Registered markers (pytest-native categorization) enable `-m` selection like
 # `-m "not integration"`; lanes themselves still run by explicit path above

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,13 @@ fail_under = 100
 directory = "htmlcov"
 
 [tool.pytest.ini_options]
+# https://docs.pytest.org/en/stable/explanation/goodpractices.html
+addopts = "--import-mode=importlib"
 # Bare `pytest` runs only the fast, deterministic unit lane; other lanes run by
 # explicit path (e.g. `pytest tests/integration`) — see AGENTS.md Testing Patterns
 testpaths = ["tests/unit"]
+# Registered markers (pytest-native categorization) enable `-m` selection like
+# `-m "not integration"`; lanes themselves still run by explicit path above
 markers = [
     "integration: requires a real external resource (e.g. Postgres); no LLM or cloud",
     "smoke: requires a live deployed service URL",


### PR DESCRIPTION
## What

Enable pytest's `importlib` import mode and document why the lane markers are intentionally retained.

## Why

`importlib` is pytest's recommended import mode for new projects (per the Good Integration Practices docs). It keeps test directories free of `__init__.py` and stops same-named modules from colliding across lanes, which `prepend` mode cannot do. While in the config, the marker block lacked a rationale comment, so it read as redundant with the directory-based lane selection.

## How

- Add `addopts = "--import-mode=importlib"` to `[tool.pytest.ini_options]`
- Add a comment explaining the registered `integration`/`smoke` markers are kept for ad-hoc `-m` selection (lanes still run by explicit path)
- Bump the pinned pytest docs URL from `7.1.x` to `stable` (project is on pytest 8.x)
- Add a CHANGELOG `Unreleased` entry under Changed

## Tests

- [x] `uv run pytest` (unit lane) passes under importlib mode (76 passed)
- [ ] Integration/smoke/eval lanes unaffected (single-module each, no basename-collision risk); covered by CI
