### PR TITLE
chore: prepare release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-12
+
 ### Added
 - Require-stage-success prod gate (`.github/workflows/require-stage-success.yml`): a tag-time, agent-agnostic gate that runs before `prod-promote` (and so before the `prod-apply` approval), so a failure halts the tag run before any reviewer is prompted. It finds the tagged commit's merge run and requires `Apply Stage` and `Smoke Stage` to have both concluded success, failing closed otherwise. Stage success is the whole gate: the promotion workflow copies the image digest-for-digest and prod deploys by digest, so prod runs exactly the digest stage validated. No digest comparison is needed: stage `{sha7}` is written only by that commit's own merge-run attempts and the tag run never rebuilds, so a green `Smoke Stage` (latest attempt) already means `{sha7}` resolves to the digest that was smoked (#211)
 - Post-deploy smoke test lane (`tests/smoke/`): after each `terraform apply`, drives the live Cloud Run URL over the real network to confirm the new revision serves end to end. Layered cheapest-first so a failure localizes the broken subsystem (L0 `/health`, L1 session create + read-back, L2 a thin `/run_sse` turn asserting only that a text part streamed, L3 delete + 404), with a readiness wait that absorbs cold-start latency. Authenticates by impersonating a dedicated invoker SA in-process to mint a Cloud Run ID token, so the same code runs locally and in CI. Runs by explicit path only (`uv run pytest tests/smoke`); `ci-cd.yml` runs it after each environment apply (`dev-smoke`/`stage-smoke`/`prod-smoke`), not in the PR gate (#101)
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration test lane now provisions Postgres with `testcontainers`: `uv run pytest tests/integration` starts a throwaway `postgres:18` via the Docker daemon and tears it down at session end, so a running Docker daemon is the only prerequisite (no manual `docker run`). The `ci.yml` `integration` job drops its service container and uses the same path, so local and CI runs are identical and the image version lives in one place. Set `INTEGRATION_DATABASE_URI` to point the lane at an already-running Postgres. The `postgres:18` major still matches the deployed `POSTGRES_18` Cloud SQL version (previously a `postgres:17` service container)
 - pytest now runs with `--import-mode=importlib` (pytest's recommended import mode for new projects), which keeps test directories free of `__init__.py` and avoids same-named modules colliding across lanes. Lane selection stays by explicit path; the registered `integration`/`smoke` markers are kept for ad-hoc `-m` selection (e.g. `-m "not integration"`)
 - Move the agent eval lane from the top-level `eval/` directory to `tests/eval/`, grouping it with the other test lanes (it stays live-model-distinct by loading the real `.env` itself). The deterministic PR gate now runs `uv run pytest tests/eval -m "deterministic"` (was `uv run pytest eval`) (#212)
+- Upgrade `google-adk` to 2.4.0 and the OpenTelemetry stack (API/SDK 1.42.1, instrumentation 0.63b1). Migrate the logging bridge to `LoggingInstrumentor().instrument(log_code_attributes=True)`, which now owns root-logger handler attachment: drop the manual SDK `LoggingHandler` (deprecated upstream; keeping it alongside the upgraded instrumentor would double-export every log record) while retaining the `code.file.path`/`function.name`/`line.number` attributes. Cap the fastapi and logging instrumentors at `<0.64`: ADK pins `opentelemetry-api<=1.42.1`, and the 0.64b0 line requires api 1.43.0 (via `semantic-conventions`), so it cannot resolve in an ADK project. Remove the obsolete `LogDeprecatedInitWarning` filter (the symbol was removed upstream) (#225)
 
 ### Fixed
 - `docs/references/agent-evals.md` is now listed in the MkDocs site nav (previously reachable only through the docs index pages)
@@ -593,7 +596,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff excludes notebooks from linting
 - Notebooks for Agent Engine creation
 
-[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/doughayden/agent-foundation/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/doughayden/agent-foundation/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/doughayden/agent-foundation/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/doughayden/agent-foundation/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/doughayden/agent-foundation/compare/v0.15.0...v0.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-foundation"
-version = "0.18.0"
+version = "0.19.0"
 description = "Opinionated, production-ready LLM Agent deployment with enterprise-grade infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "agent-foundation"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk", extra = ["gcp", "otel-gcp"] },


### PR DESCRIPTION
## What

Prepare the v0.19.0 release: bump the version, refresh the lockfile, and cut the `[Unreleased]` changelog to `[0.19.0]`.

## Why

Minor bump (0.18.0 to 0.19.0). Three feature PRs landed since v0.18.0 (#210 smoke lane, #217 require-stage-success gate, #212 App-aware eval + judge gate), so per the pre-1.x policy this is a minor release, not a patch. Cutting it lets the downstream template consumer pick up the eval features.

## How

- Bump `version` in `pyproject.toml` 0.18.0 to 0.19.0 and run `uv lock` (both committed together for `--locked` CI).
- Add the ADK 2.4.0 + OpenTelemetry upgrade entry to the changelog Changed section (#225), documenting the log-bridge migration and the `<0.64` instrumentor cap.
- Convert `## [Unreleased]` to `## [0.19.0] - 2026-07-12`, add a fresh empty `[Unreleased]`, and update the comparison links.

## Tests

- [x] `uv run ruff format` (20 files unchanged)
- [x] `uv run ruff check` (all checks passed)
- [x] `uv run mypy` (no issues, 9 source files)
- [x] `uv run pytest --cov` (85 passed, 100% coverage)
- [x] `uv lock` succeeded; `pyproject.toml` and `uv.lock` both report 0.19.0
- [x] Changelog audited against `v0.18.0..HEAD`: all 8 commits accounted for (docs-only #220 intentionally omitted), `[Unreleased]` now empty, comparison links point at `doughayden/agent-foundation`

## Release contents

Everything under `[0.19.0]` in `CHANGELOG.md` — the eval-suite work (App-aware in-process eval, judge gate, deterministic/judge markers), the post-deploy smoke lane, the require-stage-success prod gate, the per-lane test conftest split and testcontainers integration, and the ADK 2.4.0 + OTel upgrade.