### PR TITLE
docs: clarify bootstrap ordering and model vs deploy region

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 ### Required Configuration
 ### ===========================================
 
-### Google Cloud Vertex AI Model Authentication
+### Google Cloud Vertex AI Model Authentication (_LOCATION refers to the model endpoint location, not the deployment region)
 GOOGLE_GENAI_USE_VERTEXAI=TRUE
 GOOGLE_CLOUD_PROJECT=your-project-id
-GOOGLE_CLOUD_LOCATION=us-central1
+GOOGLE_CLOUD_LOCATION=global
 
 ### Unique agent identifier for cloud resources, logs, and traces
 AGENT_NAME=agent-foundation

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,6 @@ jobs:
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud
-        id: auth
         uses: google-github-actions/auth@v3
         with:
           project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
@@ -58,10 +57,9 @@ jobs:
             Provide specific, actionable feedback with line-by-line suggestions where appropriate.
           use_vertex: "true"
           claude_args: |
-            --model claude-sonnet-4-5@20250929
+            --model claude-sonnet-5
         env:
-          ANTHROPIC_VERTEX_PROJECT_ID: ${{ steps.auth.outputs.project_id }}
-          CLOUD_ML_REGION: us-east5
+          CLOUD_ML_REGION: global
 
   claude-manual-trigger:
     if: |
@@ -84,7 +82,6 @@ jobs:
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud
-        id: auth
         uses: google-github-actions/auth@v3
         with:
           project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
@@ -97,10 +94,9 @@ jobs:
           trigger_phrase: "@claude"
           use_vertex: "true"
           claude_args: |
-            --model claude-sonnet-4-5@20250929
+            --model claude-sonnet-5
         env:
-          ANTHROPIC_VERTEX_PROJECT_ID: ${{ steps.auth.outputs.project_id }}
-          CLOUD_ML_REGION: us-east5
+          CLOUD_ML_REGION: global
 
 # Claude Code Github Action
 # https://docs.anthropic.com/en/docs/claude-code/github-actions

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,7 +10,7 @@ See `.env.example` in the repository root for template configuration with inline
 |----------|----------|---------|---------|
 | **[GOOGLE_GENAI_USE_VERTEXAI](#google-cloud-vertex-ai)** | ✅ | - | Enable Vertex AI authentication |
 | **[GOOGLE_CLOUD_PROJECT](#google-cloud-vertex-ai)** | ✅ | - | GCP project ID |
-| **[GOOGLE_CLOUD_LOCATION](#google-cloud-vertex-ai)** | ✅ | - | GCP region |
+| **[GOOGLE_CLOUD_LOCATION](#google-cloud-vertex-ai)** | ✅ | - | Vertex AI model endpoint location |
 | **[AGENT_NAME](#agent-identification)** | ✅ | - | Unique agent identifier |
 | **[OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT](#opentelemetry)** | ✅ | - | Capture LLM content in traces |
 | **[BASTION_INSTANCE](#cloud-resources)** | Recommended | - | Bastion host name for IAP tunnel (docker-compose) |
@@ -51,9 +51,9 @@ These must be set for the agent to function.
 - **Where:** Set locally in `.env`, configured via Terraform for Cloud Run
 
 **GOOGLE_CLOUD_LOCATION**
-- **Value:** GCP region (e.g., `us-central1`)
-- **Purpose:** Sets the region for Vertex AI model calls and resource deployment
-- **Where:** Set locally in `.env`, configured via Terraform for Cloud Run
+- **Value:** Vertex AI model endpoint location (e.g., `global` or `us-central1`)
+- **Purpose:** Routes Vertex AI model calls only. Does not set the deployment region. Infrastructure placement is controlled separately by the `region` Terraform variable (`REGION` GitHub Environment Variable)
+- **Where:** Set locally in `.env`, configured via Terraform for Cloud Run (`TF_VAR_google_cloud_location`)
 
 ### Agent Identification
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,6 +92,10 @@ terraform -chdir=terraform/bootstrap/dev apply
 gh variable list --env dev  # or GitHub repo Settings > Environments > dev
 ```
 
+### 6. Enable the Claude PR-Review Model
+
+Opening a pull request triggers an automated Claude code review via Vertex AI. Enable its model in the dev project once, before the first PR. See [Enable the Claude PR-Review Model](references/bootstrap.md#enable-the-claude-pr-review-model-required).
+
 See [Bootstrap Reference](references/bootstrap.md) for complete bootstrap setup instructions.
 
 ## Deploy

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,15 @@ Bootstrap creates the infrastructure for automated deployments:
 - Remote Terraform state (GCS) for bootstrap and main module — bucket created by pre-bootstrap
 - GitHub Environment and Variables for CI/CD
 
-### 1. Create State Buckets (Pre-Bootstrap)
+### 1. Authenticate
+
+```bash
+gcloud auth application-default login
+gcloud config set project YOUR_PROJECT_ID  # Optional
+gh auth login
+```
+
+### 2. Create State Buckets (Pre-Bootstrap)
 
 Pre-bootstrap creates the GCS state buckets used by bootstrap and the main module. Run it before bootstrapping each environment — start with dev only, or provision all three environments at once.
 
@@ -46,7 +54,7 @@ terraform -chdir=terraform/bootstrap/pre apply
 
 See [Bootstrap Reference: Pre-Bootstrap](references/bootstrap.md#pre-bootstrap) for scope options (dev-only, full production, incremental) and how to skip pre-bootstrap if you already have a GCS bucket.
 
-### 2. Configure
+### 3. Configure
 
 Dev-only mode (default): bootstrap only the dev environment.
 
@@ -68,14 +76,6 @@ Required variables in `terraform/bootstrap/dev/terraform.tfvars`:
 
 > [!NOTE]
 > For production mode (dev → stage → prod), see [Infrastructure](infrastructure.md).
-
-### 3. Authenticate
-
-```bash
-gcloud auth application-default login
-gcloud config set project YOUR_PROJECT_ID  # Optional
-gh auth login
-```
 
 ### 4. Bootstrap
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,7 +27,7 @@ This project includes production-ready OpenTelemetry observability that provides
 - `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`: Capture LLM message content - `TRUE` or `FALSE` (required)
 
 **Optional variables:**
-- `GOOGLE_CLOUD_LOCATION`: Vertex AI region (default: `us-central1`)
+- `GOOGLE_CLOUD_LOCATION`: Vertex AI model endpoint location, not the deployment region
 - `LOG_LEVEL`: Logging verbosity - `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default: `INFO`)
 - `TELEMETRY_NAMESPACE`: Service namespace for trace grouping (default: `local`, auto-set to workspace in deployed environments)
 

--- a/docs/references/bootstrap.md
+++ b/docs/references/bootstrap.md
@@ -324,6 +324,20 @@ gh api repos/:owner/:repo/rulesets | jq '.[] | {name, enforcement, target}'
 
 See [Protection Strategies](protection-strategies.md) for detailed setup instructions.
 
+## Enable the Claude PR-Review Model (Required)
+
+The `claude.yml` workflow runs an automated code review on every pull request, plus a manual `@claude` trigger, using Claude on Vertex AI. Claude models on Vertex require a one-time enablement that Terraform cannot perform, since it needs manual acceptance of Anthropic's terms.
+
+Both review jobs run in the `dev` GitHub Environment, so they authenticate with the dev project's WIF and call Vertex in the dev project. Enable the model in the dev project only, even in production mode:
+
+1. Enable the Claude model the workflow pins (model ID at `claude_args: --model <model_id>`) in the dev project and accept the Anthropic terms, following [Use Claude models on Google Cloud](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude).
+2. Confirm the model supports the endpoint configured by `CLOUD_ML_REGION` in `claude.yml`.
+
+The dev project's bootstrap already enables the Vertex AI API and grants its WIF principal `roles/aiplatform.user`, so no further API or IAM changes are needed.
+
+> [!NOTE]
+> Without this step the review job fails fast with `is_error: true` (a 403 on the model call). This is separate from the agent's own Gemini model, which is enabled by default.
+
 ## Important Notes
 
 **Migrating Existing Local Bootstrap State:**

--- a/docs/references/bootstrap.md
+++ b/docs/references/bootstrap.md
@@ -2,6 +2,9 @@
 
 Complete bootstrap instructions for dev-only and production modes, including cross-project IAM for image promotion.
 
+> [!IMPORTANT]
+> First-time setup starts in [Getting Started](../getting-started.md) — complete its [prerequisites](../getting-started.md#prerequisites) and authenticate before running any command here. This reference is the deep dive.
+
 ## Overview
 
 Bootstrap creates one-time CI/CD infrastructure per environment:

--- a/src/agent_foundation/config.py
+++ b/src/agent_foundation/config.py
@@ -40,7 +40,7 @@ def initialize_environment[T: BaseModel](
         Validated environment configuration instance
 
     Raises:
-        SystemExit: If validation fails
+        SystemExit: Exits with code 1 if Pydantic validation fails.
 
     Examples:
         >>> # Simple case (most common)


### PR DESCRIPTION
## What

Reorder the Getting Started bootstrap steps so Authenticate runs first, add a prerequisites pointer to the bootstrap reference, and clarify that GOOGLE_CLOUD_LOCATION controls the Vertex AI model endpoint location only, not the deployment region.

## Why

Two docs gaps surfaced while bootstrapping a fresh agent-foundation-dev project. Pre-bootstrap runs terraform apply, which needs gcloud ADC, but Authenticate was step 3, after the step that required it, so a first run failed. Separately, PR #119 decoupled GOOGLE_CLOUD_LOCATION (model endpoint routing) from the deployment region (the region Terraform variable), but the env var guide's main section, .env.example, and observability.md still described it as the GCP or deployment region.

The config.py docstring touch is deliberate. It flips the ci.yml code paths-filter so this PR exercises the full CI and deploy pipeline against the newly bootstrapped dev project, validating WIF, Artifact Registry, and the Vertex eval lane end to end rather than skipping as a docs-only change.

## How

- getting-started.md: Authenticate is now step 1, remaining bootstrap steps renumbered
- references/bootstrap.md: add an IMPORTANT pointer to the Getting Started prerequisites
- environment-variables.md: GOOGLE_CLOUD_LOCATION documents the model endpoint location only, with deployment region pointed to the region Terraform variable
- .env.example: set GOOGLE_CLOUD_LOCATION to global (matches the bootstrap terraform.tfvars recommendation) and note the model-vs-deploy distinction
- observability.md: drop the stale default and align the phrasing
- config.py: tighten the initialize_environment SystemExit docstring

## Tests

- [x] ruff format and ruff check pass (pre-commit)
- [x] mypy passes (pre-commit)
- [x] pytest --cov: 85 passed, 100% coverage (local)
- [ ] CI green on PR (code-quality, integration, agent-eval, dev-plan)
- [ ] Merge deploys to dev; smoke lane passes against the live revision