### PR TITLE
docs: config clarity and Vertex Claude review setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 ### Required Configuration
 ### ===========================================
 
-### Google Cloud Vertex AI Model Authentication
+### Google Cloud Vertex AI Model Authentication (_LOCATION refers to the model endpoint location, not the deployment region)
 GOOGLE_GENAI_USE_VERTEXAI=TRUE
 GOOGLE_CLOUD_PROJECT=your-project-id
-GOOGLE_CLOUD_LOCATION=us-central1
+GOOGLE_CLOUD_LOCATION=global
 
 ### Unique agent identifier for cloud resources, logs, and traces
 AGENT_NAME=agent-foundation

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,9 @@
+# Editing this workflow: claude-code-action only runs when this file matches the
+# repository's default branch. It validates during the GitHub App token exchange
+# (a security guard, not standard GitHub Actions behavior), so a pull request
+# that changes this file skips its own review and the change takes effect only
+# after it merges. Expected: https://github.com/anthropics/claude-code-action/issues/443
+
 name: Claude PR Assistant
 
 on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,6 @@ jobs:
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud
-        id: auth
         uses: google-github-actions/auth@v3
         with:
           project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
@@ -58,10 +57,9 @@ jobs:
             Provide specific, actionable feedback with line-by-line suggestions where appropriate.
           use_vertex: "true"
           claude_args: |
-            --model claude-sonnet-4-5@20250929
+            --model claude-sonnet-5
         env:
-          ANTHROPIC_VERTEX_PROJECT_ID: ${{ steps.auth.outputs.project_id }}
-          CLOUD_ML_REGION: us-east5
+          CLOUD_ML_REGION: global
 
   claude-manual-trigger:
     if: |
@@ -84,7 +82,6 @@ jobs:
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud
-        id: auth
         uses: google-github-actions/auth@v3
         with:
           project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
@@ -97,10 +94,9 @@ jobs:
           trigger_phrase: "@claude"
           use_vertex: "true"
           claude_args: |
-            --model claude-sonnet-4-5@20250929
+            --model claude-sonnet-5
         env:
-          ANTHROPIC_VERTEX_PROJECT_ID: ${{ steps.auth.outputs.project_id }}
-          CLOUD_ML_REGION: us-east5
+          CLOUD_ML_REGION: global
 
 # Claude Code Github Action
 # https://docs.anthropic.com/en/docs/claude-code/github-actions

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Deep dives for optional follow-up:
 - [Protection Strategies](references/protection-strategies.md) - Branch, tag, environment protection
 - [Deployment Modes](references/deployment.md) - Multi-environment strategy and infrastructure
 - [CI/CD Workflows](references/cicd.md) - Workflow architecture and mechanics
+- [Claude PR Review](references/claude-pr-review.md) - Automated PR review setup: GitHub App, Vertex model, and workflow behavior
 - [Cloud SQL Scaling and Reliability](references/cloud-sql.md) - Instance tiers, backups, HA, connection pooling, monitoring
 - [Cloud Run Concurrency Tuning](references/cloud-run-concurrency-tuning.md) - Async runtime model and concurrency sizing
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,7 +10,7 @@ See `.env.example` in the repository root for template configuration with inline
 |----------|----------|---------|---------|
 | **[GOOGLE_GENAI_USE_VERTEXAI](#google-cloud-vertex-ai)** | ✅ | - | Enable Vertex AI authentication |
 | **[GOOGLE_CLOUD_PROJECT](#google-cloud-vertex-ai)** | ✅ | - | GCP project ID |
-| **[GOOGLE_CLOUD_LOCATION](#google-cloud-vertex-ai)** | ✅ | - | GCP region |
+| **[GOOGLE_CLOUD_LOCATION](#google-cloud-vertex-ai)** | ✅ | - | Vertex AI model endpoint location |
 | **[AGENT_NAME](#agent-identification)** | ✅ | - | Unique agent identifier |
 | **[OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT](#opentelemetry)** | ✅ | - | Capture LLM content in traces |
 | **[BASTION_INSTANCE](#cloud-resources)** | Recommended | - | Bastion host name for IAP tunnel (docker-compose) |
@@ -51,9 +51,9 @@ These must be set for the agent to function.
 - **Where:** Set locally in `.env`, configured via Terraform for Cloud Run
 
 **GOOGLE_CLOUD_LOCATION**
-- **Value:** GCP region (e.g., `us-central1`)
-- **Purpose:** Sets the region for Vertex AI model calls and resource deployment
-- **Where:** Set locally in `.env`, configured via Terraform for Cloud Run
+- **Value:** Vertex AI model endpoint location (e.g., `global` or `us-central1`)
+- **Purpose:** Routes Vertex AI model calls only. Does not set the deployment region. Infrastructure placement is controlled separately by the `region` Terraform variable (`REGION` GitHub Environment Variable)
+- **Where:** Set locally in `.env`, configured via Terraform for Cloud Run (`TF_VAR_google_cloud_location`)
 
 ### Agent Identification
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,9 +92,9 @@ terraform -chdir=terraform/bootstrap/dev apply
 gh variable list --env dev  # or GitHub repo Settings > Environments > dev
 ```
 
-### 6. Enable the Claude PR-Review Model
+### 6. Set Up Claude PR Review
 
-Opening a pull request triggers an automated Claude code review via Vertex AI. Enable its model in the dev project once, before the first PR. See [Enable the Claude PR-Review Model](references/bootstrap.md#enable-the-claude-pr-review-model-required).
+Opening a pull request triggers an automated Claude code review via Vertex AI. It needs a one-time setup (install the Claude GitHub App and enable the Vertex model in the dev project) before the first PR. See [Claude PR Review](references/claude-pr-review.md).
 
 See [Bootstrap Reference](references/bootstrap.md) for complete bootstrap setup instructions.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,6 +92,10 @@ terraform -chdir=terraform/bootstrap/dev apply
 gh variable list --env dev  # or GitHub repo Settings > Environments > dev
 ```
 
+### 6. Enable the Claude PR-Review Model
+
+Opening a pull request triggers an automated Claude code review via Vertex AI. Enable its model in the dev project once, before the first PR. See [Enable the Claude PR-Review Model](references/bootstrap.md#enable-the-claude-pr-review-model-required).
+
 See [Bootstrap Reference](references/bootstrap.md) for complete bootstrap setup instructions.
 
 ## Deploy

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,15 @@ Bootstrap creates the infrastructure for automated deployments:
 - Remote Terraform state (GCS) for bootstrap and main module — bucket created by pre-bootstrap
 - GitHub Environment and Variables for CI/CD
 
-### 1. Create State Buckets (Pre-Bootstrap)
+### 1. Authenticate
+
+```bash
+gcloud auth application-default login
+gcloud config set project YOUR_PROJECT_ID  # Optional
+gh auth login
+```
+
+### 2. Create State Buckets (Pre-Bootstrap)
 
 Pre-bootstrap creates the GCS state buckets used by bootstrap and the main module. Run it before bootstrapping each environment — start with dev only, or provision all three environments at once.
 
@@ -46,7 +54,7 @@ terraform -chdir=terraform/bootstrap/pre apply
 
 See [Bootstrap Reference: Pre-Bootstrap](references/bootstrap.md#pre-bootstrap) for scope options (dev-only, full production, incremental) and how to skip pre-bootstrap if you already have a GCS bucket.
 
-### 2. Configure
+### 3. Configure
 
 Dev-only mode (default): bootstrap only the dev environment.
 
@@ -68,14 +76,6 @@ Required variables in `terraform/bootstrap/dev/terraform.tfvars`:
 
 > [!NOTE]
 > For production mode (dev → stage → prod), see [Infrastructure](infrastructure.md).
-
-### 3. Authenticate
-
-```bash
-gcloud auth application-default login
-gcloud config set project YOUR_PROJECT_ID  # Optional
-gh auth login
-```
 
 ### 4. Bootstrap
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,7 +27,7 @@ This project includes production-ready OpenTelemetry observability that provides
 - `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`: Capture LLM message content - `TRUE` or `FALSE` (required)
 
 **Optional variables:**
-- `GOOGLE_CLOUD_LOCATION`: Vertex AI region (default: `us-central1`)
+- `GOOGLE_CLOUD_LOCATION`: Vertex AI model endpoint location, not the deployment region
 - `LOG_LEVEL`: Logging verbosity - `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default: `INFO`)
 - `TELEMETRY_NAMESPACE`: Service namespace for trace grouping (default: `local`, auto-set to workspace in deployed environments)
 

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -8,6 +8,7 @@ Deep-dive technical documentation for optional follow-up.
 - [Protection Strategies](protection-strategies.md) - Branch, tag, environment protection
 - [Deployment Modes](deployment.md) - Multi-environment strategy and infrastructure
 - [CI/CD Workflows](cicd.md) - Workflow architecture and mechanics
+- [Claude PR Review](claude-pr-review.md) - Automated PR review setup: GitHub App, Vertex model, and workflow behavior
 - [Cloud SQL Scaling and Reliability](cloud-sql.md) - Instance tiers, backups, HA, connection pooling, monitoring
 - [Cloud Run Concurrency Tuning](cloud-run-concurrency-tuning.md) - Async runtime model and concurrency sizing
 

--- a/docs/references/bootstrap.md
+++ b/docs/references/bootstrap.md
@@ -324,6 +324,20 @@ gh api repos/:owner/:repo/rulesets | jq '.[] | {name, enforcement, target}'
 
 See [Protection Strategies](protection-strategies.md) for detailed setup instructions.
 
+## Enable the Claude PR-Review Model (Required)
+
+The `claude.yml` workflow runs an automated code review on every pull request, plus a manual `@claude` trigger, using Claude on Vertex AI. Claude models on Vertex require a one-time enablement that Terraform cannot perform, since it needs manual acceptance of Anthropic's terms.
+
+Both review jobs run in the `dev` GitHub Environment, so they authenticate with the dev project's WIF and call Vertex in the dev project. Enable the model in the dev project only, even in production mode:
+
+1. Enable the Claude model the workflow pins (model ID at `claude_args: --model <model_id>`) in the dev project and accept the Anthropic terms, following [Use Claude models on Google Cloud](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude).
+2. Confirm the model supports the endpoint configured by `CLOUD_ML_REGION` in `claude.yml`.
+
+The dev project's bootstrap already enables the Vertex AI API and grants its WIF principal `roles/aiplatform.user`, so no further API or IAM changes are needed.
+
+> [!NOTE]
+> Without this step the review job fails fast with `is_error: true` (a 403 on the model call). This is separate from the agent's own Gemini model, which is enabled by default.
+
 ## Important Notes
 
 **Migrating Existing Local Bootstrap State:**

--- a/docs/references/bootstrap.md
+++ b/docs/references/bootstrap.md
@@ -338,6 +338,17 @@ The dev project's bootstrap already enables the Vertex AI API and grants its WIF
 > [!NOTE]
 > Without this step the review job fails fast with `is_error: true` (a 403 on the model call). This is separate from the agent's own Gemini model, which is enabled by default.
 
+### Editing the review workflow
+
+`claude-code-action` obtains its GitHub token by exchanging an OIDC token, and that exchange only succeeds when `claude.yml` matches the version on the repository's default branch. This is a security guard in the action, not standard GitHub Actions behavior. A pull request that changes `claude.yml` therefore skips its own review, logging:
+
+```text
+Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.
+Action skipped due to workflow validation error. ... your workflow will begin working once you merge your PR.
+```
+
+This is expected ([claude-code-action#443](https://github.com/anthropics/claude-code-action/issues/443)). The updated review runs on pull requests opened after the change merges to the default branch. A fresh repo created from the template already ships the matching workflow, so its first pull request is reviewed normally.
+
 ## Important Notes
 
 **Migrating Existing Local Bootstrap State:**

--- a/docs/references/bootstrap.md
+++ b/docs/references/bootstrap.md
@@ -2,6 +2,9 @@
 
 Complete bootstrap instructions for dev-only and production modes, including cross-project IAM for image promotion.
 
+> [!IMPORTANT]
+> First-time setup starts in [Getting Started](../getting-started.md) — complete its [prerequisites](../getting-started.md#prerequisites) and authenticate before running any command here. This reference is the deep dive.
+
 ## Overview
 
 Bootstrap creates one-time CI/CD infrastructure per environment:

--- a/docs/references/bootstrap.md
+++ b/docs/references/bootstrap.md
@@ -324,30 +324,9 @@ gh api repos/:owner/:repo/rulesets | jq '.[] | {name, enforcement, target}'
 
 See [Protection Strategies](protection-strategies.md) for detailed setup instructions.
 
-## Enable the Claude PR-Review Model (Required)
+## Claude PR Review
 
-The `claude.yml` workflow runs an automated code review on every pull request, plus a manual `@claude` trigger, using Claude on Vertex AI. Claude models on Vertex require a one-time enablement that Terraform cannot perform, since it needs manual acceptance of Anthropic's terms.
-
-Both review jobs run in the `dev` GitHub Environment, so they authenticate with the dev project's WIF and call Vertex in the dev project. Enable the model in the dev project only, even in production mode:
-
-1. Enable the Claude model the workflow pins (model ID at `claude_args: --model <model_id>`) in the dev project and accept the Anthropic terms, following [Use Claude models on Google Cloud](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude).
-2. Confirm the model supports the endpoint configured by `CLOUD_ML_REGION` in `claude.yml`.
-
-The dev project's bootstrap already enables the Vertex AI API and grants its WIF principal `roles/aiplatform.user`, so no further API or IAM changes are needed.
-
-> [!NOTE]
-> Without this step the review job fails fast with `is_error: true` (a 403 on the model call). This is separate from the agent's own Gemini model, which is enabled by default.
-
-### Editing the review workflow
-
-`claude-code-action` obtains its GitHub token by exchanging an OIDC token, and that exchange only succeeds when `claude.yml` matches the version on the repository's default branch. This is a security guard in the action, not standard GitHub Actions behavior. A pull request that changes `claude.yml` therefore skips its own review, logging:
-
-```text
-Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.
-Action skipped due to workflow validation error. ... your workflow will begin working once you merge your PR.
-```
-
-This is expected ([claude-code-action#443](https://github.com/anthropics/claude-code-action/issues/443)). The updated review runs on pull requests opened after the change merges to the default branch. A fresh repo created from the template already ships the matching workflow, so its first pull request is reviewed normally.
+The `claude.yml` workflow adds an automated Claude code review on pull requests plus a manual `@claude` trigger. It needs a one-time setup beyond bootstrap: install the Claude GitHub App and enable the Vertex model in the dev project. See [Claude PR Review](claude-pr-review.md).
 
 ## Important Notes
 

--- a/docs/references/claude-pr-review.md
+++ b/docs/references/claude-pr-review.md
@@ -1,0 +1,50 @@
+# Claude PR Review
+
+Automated code review on pull requests, powered by Claude on Vertex AI.
+
+## Overview
+
+The `claude.yml` workflow adds two jobs to the repository:
+
+- An automated code review on every pull request when it is opened.
+- A manual `@claude` trigger for on-demand review or assistance from a comment.
+
+Both jobs run in the `dev` GitHub Environment, authenticate with the dev project's Workload Identity Federation (provisioned by bootstrap), and call Claude on Vertex AI in the dev project. The review model and endpoint are pinned in `claude.yml` (`claude_args: --model` and `CLOUD_ML_REGION`).
+
+## Prerequisites
+
+Two one-time manual steps that Terraform cannot perform. Bootstrap already provisions the Workload Identity Federation and Vertex access the workflow uses, so these are the only extra steps.
+
+### 1. Install the Claude GitHub App
+
+`claude-code-action` mints its GitHub token by exchanging an OIDC token with the Claude GitHub App. Without the app installed on the repository, the review cannot run. Install it from [github.com/apps/claude](https://github.com/apps/claude), following Anthropic's [Using with Amazon Bedrock and Google Cloud](https://code.claude.com/docs/en/github-actions#using-with-amazon-bedrock-and-google-cloud).
+
+> [!NOTE]
+> Skip that guide's Workload Identity Federation and service-account steps. Bootstrap already provisions the WIF the workflow uses, and grants `roles/aiplatform.user` directly to the WIF principal rather than impersonating a service account, which is Google Cloud's recommended [direct resource access](https://docs.cloud.google.com/iam/docs/workload-identity-federation#access_management) pattern. `claude.yml` reads the `WORKLOAD_IDENTITY_PROVIDER` and `GOOGLE_CLOUD_PROJECT` GitHub Variables bootstrap creates, so you only need the app install here.
+
+### 2. Enable the Claude model in the dev project
+
+Both review jobs run in the `dev` GitHub Environment and call Vertex in the dev project, so enable the model in the dev project only, even in production mode.
+
+1. Enable the Claude model the workflow pins (model ID at `claude_args: --model <model_id>`) in the dev project and accept the Anthropic terms, following [Use Claude models on Google Cloud](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude).
+2. Confirm the model supports the endpoint configured by `CLOUD_ML_REGION` in `claude.yml`.
+
+The dev project's bootstrap already enables the Vertex AI API and grants its WIF principal `roles/aiplatform.user`, so no further API or IAM changes are needed.
+
+> [!NOTE]
+> Without this step the review job fails fast with `is_error: true` (a 403 on the model call). This is separate from the agent's own Gemini model, which is enabled by default.
+
+## Editing the review workflow
+
+`claude-code-action` obtains its GitHub token by exchanging an OIDC token, and that exchange only succeeds when `claude.yml` matches the version on the repository's default branch. This is a security guard in the action, not standard GitHub Actions behavior. A pull request that changes `claude.yml` therefore skips its own review, logging:
+
+```text
+Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.
+Action skipped due to workflow validation error. ... your workflow will begin working once you merge your PR.
+```
+
+This is expected ([claude-code-action#443](https://github.com/anthropics/claude-code-action/issues/443)). The updated review runs on pull requests opened after the change merges to the default branch. A fresh repo created from the template already ships the matching workflow, so its first pull request is reviewed normally.
+
+---
+
+← [Back to References](README.md) | [Documentation](../README.md)

--- a/src/agent_foundation/config.py
+++ b/src/agent_foundation/config.py
@@ -40,7 +40,7 @@ def initialize_environment[T: BaseModel](
         Validated environment configuration instance
 
     Raises:
-        SystemExit: If validation fails
+        SystemExit: Exits with code 1 if Pydantic validation fails.
 
     Examples:
         >>> # Simple case (most common)


### PR DESCRIPTION
## What

Clarify configuration docs (bootstrap step ordering, and Vertex model region vs deployment region), and wire the Claude PR-review workflow to run against the newly bootstrapped dev project.

## Why

Surfaced while bootstrapping a fresh agent-foundation-dev project. Pre-bootstrap runs terraform apply, which needs gcloud ADC, but Authenticate was step 3, so a first run failed. Separately, PR #119 decoupled GOOGLE_CLOUD_LOCATION (Vertex model endpoint) from the deployment region, but the env var guide, .env.example, and observability.md still described it as the deployment region. And the Claude auto-review authenticated fine but errored because its model was not enabled in the new project.

The config.py docstring touch is deliberate. It flips the ci.yml code paths-filter so this PR exercises the full CI and deploy pipeline against the new dev project rather than skipping as a docs-only change. Opening this PR fresh also re-triggers the Claude auto-review, which only fires on pull_request opened, now that the Vertex model is enabled.

## How

- getting-started.md: Authenticate is step 1, and a new step 6 covers enabling the Claude review model before deploy
- references/bootstrap.md: prerequisites pointer, plus a required section for enabling the Vertex review model in the dev project (dev only, via Google Cloud's Claude models doc)
- environment-variables.md / .env.example / observability.md: GOOGLE_CLOUD_LOCATION documents the Vertex model endpoint location only, with deployment region pointed to the region Terraform variable; .env.example defaults to global
- rename claude.yaml to claude.yml; drop the redundant ANTHROPIC_VERTEX_PROJECT_ID, set CLOUD_ML_REGION to global, pin the review model to claude-sonnet-5
- config.py: tighten the initialize_environment SystemExit docstring

## Tests

- [x] ruff format and ruff check clean (pre-commit)
- [x] mypy clean (pre-commit)
- [x] pytest --cov: 85 passed, 100% coverage (local)
- [ ] CI green on PR (code-quality, integration, agent-eval, dev-plan)
- [ ] Claude auto-review runs green on the new claude.yml (global + Sonnet 5)
- [ ] Merge deploys to dev; smoke lane passes against the live revision