### PR TITLE
fix(ci): set Vertex project env for Claude review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,6 +66,7 @@ jobs:
             --model claude-sonnet-5
         env:
           CLOUD_ML_REGION: global
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GOOGLE_CLOUD_PROJECT }}
 
   claude-manual-trigger:
     if: |
@@ -103,6 +104,7 @@ jobs:
             --model claude-sonnet-5
         env:
           CLOUD_ML_REGION: global
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GOOGLE_CLOUD_PROJECT }}
 
 # Claude Code Github Action
 # https://docs.anthropic.com/en/docs/claude-code/github-actions


### PR DESCRIPTION
## What

Set `ANTHROPIC_VERTEX_PROJECT_ID` (sourced from `vars.GOOGLE_CLOUD_PROJECT`) in the env of both `claude.yml` jobs.

## Why

`claude-code-action` runs its own environment validation and requires `ANTHROPIC_VERTEX_PROJECT_ID` by that exact name when `use_vertex: "true"`. It does not fall back to `GOOGLE_CLOUD_PROJECT`. #230 dropped the var on the assumption the auth step supplied it, but the auth step exports `GOOGLE_CLOUD_PROJECT`, a different name, so every review run now fails validation with:

```
Environment variable validation failed:
  - ANTHROPIC_VERTEX_PROJECT_ID is required when using Google Vertex AI.
```

The break surfaced only now because of claude-code-action#443: a PR that edits `claude.yml` skips its own review, so #230's change took effect only after merge, and the next PR was the first to run it.

## How

- Add `ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GOOGLE_CLOUD_PROJECT }}` to the `env` of `claude-auto-review` and `claude-manual-trigger`.
- Source from the repo var rather than restoring the old `steps.auth.outputs.project_id` form, so the auth step needs no `id` and the value stays out of the file.
- `CLOUD_ML_REGION: global` is unchanged.

## Tests

- [x] YAML lint passes (pre-commit `check yaml`)
- [ ] Confirmed on the next PR opened after this merges: the Claude review job runs past env validation (this PR skips its own review per claude-code-action#443, so it self-validates only after merge)