### PR TITLE
feat(review): add inline PR comments and Anthropic auth paths

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,14 @@
+# Inline review comments: the tag-mode tool allowlist is fixed, and the inline
+# comment MCP server is only started when the allowlist names one of its tools,
+# so create_inline_comment is granted through claude_args. Classification of
+# buffered comments is off: it only runs when an Anthropic API key is present,
+# which would make the set of posted comments depend on the auth path below.
+#
+# Model auth: Vertex AI by default. Either the ANTHROPIC_API_KEY or the
+# CLAUDE_CODE_OAUTH_TOKEN repository secret overrides it and calls the Anthropic
+# API directly instead, with no GCP dependency. ANTHROPIC_API_KEY wins if both
+# are set. See docs/references/claude-pr-review.md.
+#
 # Editing this workflow: claude-code-action only runs when this file matches the
 # repository's default branch. It validates during the GitHub App token exchange
 # (a security guard, not standard GitHub Actions behavior), so a pull request
@@ -37,13 +48,30 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    env:
+      USE_ANTHROPIC_AUTH: ${{ secrets.ANTHROPIC_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
+      - name: Report model auth path
+        env:
+          HAS_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+          HAS_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+          GCP_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+        run: |
+          if [[ "$HAS_API_KEY" == "true" ]]; then
+            echo "Model auth: Anthropic API key"
+          elif [[ "$HAS_OAUTH_TOKEN" == "true" ]]; then
+            echo "Model auth: Claude Code OAuth token"
+          else
+            echo "Model auth: Vertex AI (project $GCP_PROJECT)"
+          fi
+
       - name: Authenticate to Google Cloud
+        if: env.USE_ANTHROPIC_AUTH != 'true'
         uses: google-github-actions/auth@v3
         with:
           project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
@@ -53,6 +81,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           track_progress: true
+          classify_inline_comments: "false"
           prompt: |
             Please provide a comprehensive code review of this pull request. Focus on:
             - Code quality and best practices
@@ -60,10 +89,18 @@ jobs:
             - Performance implications
             - Documentation and testing completeness
 
-            Provide specific, actionable feedback with line-by-line suggestions where appropriate.
-          use_vertex: "true"
+            Post findings that concern specific lines as inline review comments on
+            those lines, using the create_inline_comment tool. Include a
+            ```suggestion``` block whenever you can express the fix as a drop-in
+            replacement for the lines you are commenting on. Reserve the tracking
+            comment for the overall summary and for findings that span the change
+            as a whole.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY == '' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          use_vertex: ${{ env.USE_ANTHROPIC_AUTH != 'true' }}
           claude_args: |
             --model claude-sonnet-5
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"
         env:
           CLOUD_ML_REGION: global
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GOOGLE_CLOUD_PROJECT }}
@@ -82,13 +119,30 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    env:
+      USE_ANTHROPIC_AUTH: ${{ secrets.ANTHROPIC_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
+      - name: Report model auth path
+        env:
+          HAS_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+          HAS_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+          GCP_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+        run: |
+          if [[ "$HAS_API_KEY" == "true" ]]; then
+            echo "Model auth: Anthropic API key"
+          elif [[ "$HAS_OAUTH_TOKEN" == "true" ]]; then
+            echo "Model auth: Claude Code OAuth token"
+          else
+            echo "Model auth: Vertex AI (project $GCP_PROJECT)"
+          fi
+
       - name: Authenticate to Google Cloud
+        if: env.USE_ANTHROPIC_AUTH != 'true'
         uses: google-github-actions/auth@v3
         with:
           project_id: ${{ vars.GOOGLE_CLOUD_PROJECT }}
@@ -98,10 +152,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           track_progress: true
+          classify_inline_comments: "false"
           trigger_phrase: "@claude"
-          use_vertex: "true"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY == '' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          use_vertex: ${{ env.USE_ANTHROPIC_AUTH != 'true' }}
           claude_args: |
             --model claude-sonnet-5
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"
         env:
           CLOUD_ML_REGION: global
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GOOGLE_CLOUD_PROJECT }}
@@ -125,3 +183,14 @@ jobs:
 # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables
 # Set the GitHub Actions > Repository variables GOOGLE_CLOUD_PROJECT to the Google Cloud project ID
 # Set the GitHub Actions > Repository variables WORKLOAD_IDENTITY_PROVIDER to the workload ID federation principal identifier
+#
+# Configure Repository Secrets
+# https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
+# Set the GitHub Actions > Repository secrets ANTHROPIC_API_KEY to use an Anthropic organization API key instead of Vertex AI
+# Set the GitHub Actions > Repository secrets CLAUDE_CODE_OAUTH_TOKEN to use a Claude Code OAuth token instead of Vertex AI
+#
+# Anthropic Console (organization API keys)
+# https://console.anthropic.com/settings/keys
+#
+# Claude Code OAuth token (generate with: claude setup-token)
+# https://code.claude.com/docs/en/github-actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Inline review comments on the Claude PR review (`claude.yml`): line-specific findings now post on the lines they concern, with committable `suggestion` blocks, instead of collapsing into one tracking comment. Tag mode's tool allowlist is fixed, so `create_inline_comment` is granted via `claude_args`; without it the inline-comment MCP server never starts. Comment classification is disabled, since it runs only when an Anthropic API key is present and would otherwise make the set of posted comments depend on the auth path (#194)
+- Direct-to-Anthropic auth for the Claude PR review (`claude.yml`): setting either the `ANTHROPIC_API_KEY` repository secret (an Anthropic organization API key) or `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) overrides the default Vertex AI path, so the review runs without Vertex model access. `ANTHROPIC_API_KEY` wins when both are set; Vertex AI remains the default when neither is. A new "Report model auth path" step names the selected path in the job log
+
 ### Fixed
 - Agent eval gate no longer false-passes when model inference is entirely unavailable. ADK swallows per-case inference failures (403/quota/network) and drops the case from scoring, so `AgentEvaluator` passed vacuously over an empty metric set and a dead endpoint read as green. Preflight liveness probes now make one minimal live call per model role before the gates run, the agent's inference model and each judge autorater, and fail the lane fast (reporting the exact endpoint reply or error) when one is unreachable. Each probe reads its role's model from source (`ROOT_AGENT_MODEL`, `full_eval_config.json`), so swapping a model re-points its probe automatically (#229)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Deep dives for optional follow-up:
 - [Protection Strategies](references/protection-strategies.md) - Branch, tag, environment protection
 - [Deployment Modes](references/deployment.md) - Multi-environment strategy and infrastructure
 - [CI/CD Workflows](references/cicd.md) - Workflow architecture and mechanics
-- [Claude PR Review](references/claude-pr-review.md) - Automated PR review setup: GitHub App, Vertex model, and workflow behavior
+- [Claude PR Review](references/claude-pr-review.md) - Automated PR review setup: GitHub App, model auth paths, and workflow behavior
 - [Cloud SQL Scaling and Reliability](references/cloud-sql.md) - Instance tiers, backups, HA, connection pooling, monitoring
 - [Cloud Run Concurrency Tuning](references/cloud-run-concurrency-tuning.md) - Async runtime model and concurrency sizing
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -30,7 +30,7 @@ See `.env.example` in the repository root for template configuration with inline
 
 **Cloud Run auto-set:** [K_REVISION](#cloud-run-auto-set-read-only)
 
-**CI/CD only:** [TF_VAR_*](#cicd-only) variables (GitHub Actions)
+**CI/CD only:** [TF_VAR_*](#terraform-inputs-tf_var_) variables and [repository secrets](#repository-secrets) (GitHub Actions)
 
 ---
 
@@ -260,6 +260,21 @@ Override runtime config via GitHub Environment Variables (mapped to `TF_VAR_*`):
 **TF_VAR_otel_instrumentation_genai_capture_message_content**
 - **Source:** `${{ vars.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT }}` (optional GitHub Environment Variable)
 - **Purpose:** Override OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT for Cloud Run deployment
+
+### Repository Secrets
+
+Set in GitHub Actions > Secrets and variables > Actions. Both select the model auth path for the `claude.yml` PR review; when neither is set, the review authenticates via Workload Identity Federation and calls Vertex AI. See [Claude PR Review](references/claude-pr-review.md).
+
+**ANTHROPIC_API_KEY**
+- **Source:** Repository secret (optional, set manually)
+- **Purpose:** Runs the review against the Anthropic API with an organization API key instead of Vertex AI. Takes precedence over `CLAUDE_CODE_OAUTH_TOKEN`
+
+**CLAUDE_CODE_OAUTH_TOKEN**
+- **Source:** Repository secret (optional, set manually; generate with `claude setup-token`)
+- **Purpose:** Runs the review against the Anthropic API with an individual account's Claude Code OAuth token instead of Vertex AI. Ignored when `ANTHROPIC_API_KEY` is set. Expires about a year after issue and must be rotated
+
+> [!NOTE]
+> These two names are also what the local Claude Code CLI reads for its own authentication. The "do not set locally" guidance above applies to the `TF_VAR_*` variables, not to these.
 
 ---
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -271,7 +271,7 @@ Set in GitHub Actions > Secrets and variables > Actions. Both select the model a
 
 **CLAUDE_CODE_OAUTH_TOKEN**
 - **Source:** Repository secret (optional, set manually; generate with `claude setup-token`)
-- **Purpose:** Runs the review against the Anthropic API with an individual account's Claude Code OAuth token instead of Vertex AI. Ignored when `ANTHROPIC_API_KEY` is set. Expires about a year after issue and must be rotated
+- **Purpose:** Runs the review against the Anthropic API with an individual account's Claude Code OAuth token instead of Vertex AI. Ignored when `ANTHROPIC_API_KEY` is set. Expires about a year after creation and must be rotated
 
 > [!NOTE]
 > These two names are also what the local Claude Code CLI reads for its own authentication. The "do not set locally" guidance above applies to the `TF_VAR_*` variables, not to these.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ gh variable list --env dev  # or GitHub repo Settings > Environments > dev
 
 ### 6. Set Up Claude PR Review
 
-Opening a pull request triggers an automated Claude code review via Vertex AI. It needs a one-time setup (install the Claude GitHub App and enable the Vertex model in the dev project) before the first PR. See [Claude PR Review](references/claude-pr-review.md).
+Opening a pull request triggers an automated Claude code review. It needs a one-time setup before the first PR: install the Claude GitHub App, then pick a model auth path, either Vertex AI in the dev project or a direct Anthropic credential. See [Claude PR Review](references/claude-pr-review.md).
 
 See [Bootstrap Reference](references/bootstrap.md) for complete bootstrap setup instructions.
 

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -8,7 +8,7 @@ Deep-dive technical documentation for optional follow-up.
 - [Protection Strategies](protection-strategies.md) - Branch, tag, environment protection
 - [Deployment Modes](deployment.md) - Multi-environment strategy and infrastructure
 - [CI/CD Workflows](cicd.md) - Workflow architecture and mechanics
-- [Claude PR Review](claude-pr-review.md) - Automated PR review setup: GitHub App, Vertex model, and workflow behavior
+- [Claude PR Review](claude-pr-review.md) - Automated PR review setup: GitHub App, model auth paths, and workflow behavior
 - [Cloud SQL Scaling and Reliability](cloud-sql.md) - Instance tiers, backups, HA, connection pooling, monitoring
 - [Cloud Run Concurrency Tuning](cloud-run-concurrency-tuning.md) - Async runtime model and concurrency sizing
 

--- a/docs/references/bootstrap.md
+++ b/docs/references/bootstrap.md
@@ -326,7 +326,7 @@ See [Protection Strategies](protection-strategies.md) for detailed setup instruc
 
 ## Claude PR Review
 
-The `claude.yml` workflow adds an automated Claude code review on pull requests plus a manual `@claude` trigger. It needs a one-time setup beyond bootstrap: install the Claude GitHub App and enable the Vertex model in the dev project. See [Claude PR Review](claude-pr-review.md).
+The `claude.yml` workflow adds an automated Claude code review on pull requests plus a manual `@claude` trigger. It needs a one-time setup beyond bootstrap: install the Claude GitHub App, then pick a model auth path, either enabling the Claude model in the dev project for the default Vertex AI path or setting a repository secret to call the Anthropic API instead. See [Claude PR Review](claude-pr-review.md).
 
 ## Important Notes
 

--- a/docs/references/claude-pr-review.md
+++ b/docs/references/claude-pr-review.md
@@ -1,6 +1,6 @@
 # Claude PR Review
 
-Automated code review on pull requests, powered by Claude on Vertex AI.
+Automated code review on pull requests, powered by Claude.
 
 ## Overview
 
@@ -9,30 +9,93 @@ The `claude.yml` workflow adds two jobs to the repository:
 - An automated code review on every pull request when it is opened.
 - A manual `@claude` trigger for on-demand review or assistance from a comment.
 
-Both jobs run in the `dev` GitHub Environment, authenticate with the dev project's Workload Identity Federation (provisioned by bootstrap), and call Claude on Vertex AI in the dev project. The review model and endpoint are pinned in `claude.yml` (`claude_args: --model` and `CLOUD_ML_REGION`).
+Both jobs run in the `dev` GitHub Environment. The review model is pinned in `claude.yml` (`claude_args: --model`).
+
+Findings tied to specific lines are posted as inline review comments on those lines, with a `suggestion` block where the fix is a drop-in replacement, so they can be committed from the Files changed tab. The tracking comment carries the summary and anything that spans the whole change. Review feedback also carries "Fix this" links that open Claude Code with the finding's context.
+
+## Inline review comments
+
+The tool that posts them is granted in `claude.yml` through `claude_args`:
+
+```yaml
+claude_args: |
+  --allowedTools "mcp__github_inline_comment__create_inline_comment"
+```
+
+This is required, not decorative. `track_progress: true` puts the action in tag mode, whose tool allowlist is otherwise fixed, and the inline-comment MCP server is started only when the allowlist names one of its tools. Without this line the server never starts, Claude has no way to place a line comment, and every finding collapses into the single tracking comment. Multiple `--allowedTools` occurrences accumulate rather than override, so this grants the tool without displacing the ones tag mode adds.
+
+`classify_inline_comments` is set to `"false"`. Left at its default, the action buffers each inline comment and, after the session, asks a model to classify it as real feedback or a test probe, dropping the ones judged to be probes and logging a warning. That classification only runs when an Anthropic API key is present, so it would silently make the set of posted comments depend on which model auth path the repository uses. Setting it to `"false"` posts every inline comment on all three paths.
+
+## Choosing a model auth path
+
+The workflow reaches Claude one of three ways. Vertex AI is the default; either of two repository secrets overrides it.
+
+| | Vertex AI (default) | Anthropic API key | Claude Code OAuth token |
+|---|---|---|---|
+| Setup | Workload Identity Federation, provisioned by bootstrap | `ANTHROPIC_API_KEY` repository secret | `CLAUDE_CODE_OAUTH_TOKEN` repository secret |
+| Requires GCP | Yes | No | No |
+| Credential owner | The GCP organization | The Anthropic organization | An individual's Claude account |
+| Billed to | The dev project's Google Cloud billing account | The Anthropic organization's workspace | The account's Claude subscription |
+| Expires | No | No | Yes, about a year after issue |
+| Model endpoint | `CLOUD_ML_REGION` in `claude.yml` | Anthropic API | Anthropic API |
+
+**Precedence:** `ANTHROPIC_API_KEY` wins if both secrets are set, and either one takes precedence over Vertex AI. The workflow applies this explicitly rather than leaving it to credential resolution inside the action, so the rule is visible in `claude.yml`.
+
+All three paths need the Claude GitHub App installed (below). Switching is adding or removing a secret. No workflow edit in any direction.
+
+> [!TIP]
+> Prefer the Anthropic API key over the OAuth token for a shared or organization-owned repository. The key is owned by the organization rather than a person, carries a workspace spend limit, is revocable independently of any individual, and does not expire. The OAuth token is the fastest path to a working review for an individual developer, at the cost of a yearly rotation.
 
 ## Prerequisites
 
-Two one-time manual steps that Terraform cannot perform. Bootstrap already provisions the Workload Identity Federation and Vertex access the workflow uses, so these are the only extra steps.
+### 1. Install the Claude GitHub App (all paths)
 
-### 1. Install the Claude GitHub App
+`claude-code-action` mints its GitHub token by exchanging an OIDC token with the Claude GitHub App. Without the app installed on the repository, the review cannot run regardless of which model auth path you use. Install it from [github.com/apps/claude](https://github.com/apps/claude).
 
-`claude-code-action` mints its GitHub token by exchanging an OIDC token with the Claude GitHub App. Without the app installed on the repository, the review cannot run. Install it from [github.com/apps/claude](https://github.com/apps/claude), following Anthropic's [Using with Amazon Bedrock and Google Cloud](https://code.claude.com/docs/en/github-actions#using-with-amazon-bedrock-and-google-cloud).
-
-> [!NOTE]
-> Skip that guide's Workload Identity Federation and service-account steps. Bootstrap already provisions the WIF the workflow uses, and grants `roles/aiplatform.user` directly to the WIF principal rather than impersonating a service account, which is Google Cloud's recommended [direct resource access](https://docs.cloud.google.com/iam/docs/workload-identity-federation#access_management) pattern. `claude.yml` reads the `WORKLOAD_IDENTITY_PROVIDER` and `GOOGLE_CLOUD_PROJECT` GitHub Variables bootstrap creates, so you only need the app install here.
-
-### 2. Enable the Claude model in the dev project
+### 2a. Vertex AI path: enable the Claude model in the dev project
 
 Both review jobs run in the `dev` GitHub Environment and call Vertex in the dev project, so enable the model in the dev project only, even in production mode.
 
 1. Enable the Claude model the workflow pins (model ID at `claude_args: --model <model_id>`) in the dev project and accept the Anthropic terms, following [Use Claude models on Google Cloud](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude).
 2. Confirm the model supports the endpoint configured by `CLOUD_ML_REGION` in `claude.yml`.
+3. Confirm the project has quota for that model on that endpoint.
 
 The dev project's bootstrap already enables the Vertex AI API and grants its WIF principal `roles/aiplatform.user`, so no further API or IAM changes are needed.
 
 > [!NOTE]
-> Without this step the review job fails fast with `is_error: true` (a 403 on the model call). This is separate from the agent's own Gemini model, which is enabled by default.
+> Skip Anthropic's [Using with Amazon Bedrock and Google Cloud](https://code.claude.com/docs/en/github-actions#using-with-amazon-bedrock-and-google-cloud) guide's Workload Identity Federation and service-account steps. Bootstrap already provisions the WIF the workflow uses, and grants `roles/aiplatform.user` directly to the WIF principal rather than impersonating a service account, which is Google Cloud's recommended [direct resource access](https://docs.cloud.google.com/iam/docs/workload-identity-federation#access_management) pattern. `claude.yml` reads the `WORKLOAD_IDENTITY_PROVIDER` and `GOOGLE_CLOUD_PROJECT` GitHub Variables bootstrap creates.
+
+### 2b. API key path: add an organization API key
+
+1. In the [Anthropic Console](https://console.anthropic.com/settings/keys), create an API key under the organization. Scope it to a Workspace so its spend is capped and tracked separately.
+2. Add it as the `ANTHROPIC_API_KEY` repository secret (GitHub Actions > Secrets and variables > Actions).
+3. Confirm the workspace has access to the model the workflow pins.
+
+Nothing else changes. The workflow skips its Google Cloud authentication step whenever either override secret is present, so the review runs without touching GCP.
+
+> [!NOTE]
+> Use an organization key rather than a personal one. It survives staff changes, is revocable independently of any individual, and carries the workspace's spend limit.
+
+### 2c. OAuth token path: add a Claude Code OAuth token
+
+1. Run `claude setup-token` in a terminal and complete the browser sign-in. It prints a long-lived OAuth token tied to the Claude account you signed in with.
+2. Add it as the `CLAUDE_CODE_OAUTH_TOKEN` repository secret (GitHub Actions > Secrets and variables > Actions).
+3. Confirm the account's plan covers the model the workflow pins.
+
+Leave `ANTHROPIC_API_KEY` unset, or the API key takes precedence.
+
+> [!IMPORTANT]
+> The token expires roughly a year after it is issued, and nothing warns you beforehand. The review simply starts failing. Re-run `claude setup-token` and replace the secret to rotate it.
+
+## Troubleshooting
+
+**The review job fails with `is_error: true` and no review output.** The model call did not succeed. Start with the job's "Report model auth path" step, which names the path that ran. On Vertex AI, confirm the model is enabled in the dev project and that the project has quota for it on the endpoint `CLOUD_ML_REGION` configures. On the API key, confirm the key is valid and the workspace has both model access and remaining budget. On the OAuth token, confirm it has not expired and the account's plan covers the pinned model. Switching to another path is the fastest way to isolate whether the problem is model access.
+
+**The review ran on an unexpected auth path.** Both override secrets are probably set. `ANTHROPIC_API_KEY` wins over `CLAUDE_CODE_OAUTH_TOKEN`; remove the one you do not want.
+
+**The automatic review fails on a pull request from a fork.** GitHub withholds secrets from `pull_request` runs triggered by a fork and downgrades the token to read-only. No model auth path can work, and the job fails rather than being skipped, so the check goes red. This predates the override secrets and applies to the Vertex AI path too.
+
+Commenting `@claude` on that same pull request does work. Comment events (`issue_comment`, `pull_request_review_comment`, `pull_request_review`) run in the base repository's context with full secrets and the workflow's declared permissions, so `claude-manual-trigger` authenticates normally. Use it to review an outside contribution.
 
 ## Editing the review workflow
 
@@ -44,6 +107,8 @@ Action skipped due to workflow validation error. ... your workflow will begin wo
 ```
 
 This is expected ([claude-code-action#443](https://github.com/anthropics/claude-code-action/issues/443)). The updated review runs on pull requests opened after the change merges to the default branch. A fresh repo created from the template already ships the matching workflow, so its first pull request is reviewed normally.
+
+Adding or removing the `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` secret is not a workflow edit and does not trigger this guard. It takes effect on the next run.
 
 ---
 

--- a/docs/references/claude-pr-review.md
+++ b/docs/references/claude-pr-review.md
@@ -36,7 +36,7 @@ The workflow reaches Claude one of three ways. Vertex AI is the default; either 
 | Requires GCP | Yes | No | No |
 | Credential owner | The GCP organization | The Anthropic organization | An individual's Claude account |
 | Billed to | The dev project's Google Cloud billing account | The Anthropic organization's workspace | The account's Claude subscription |
-| Expires | No | No | Yes, about a year after issue |
+| Expires | No | No | Yes, about a year after creation |
 | Model endpoint | `CLOUD_ML_REGION` in `claude.yml` | Anthropic API | Anthropic API |
 
 **Precedence:** `ANTHROPIC_API_KEY` wins if both secrets are set, and either one takes precedence over Vertex AI. The workflow applies this explicitly rather than leaving it to credential resolution inside the action, so the rule is visible in `claude.yml`.
@@ -85,7 +85,7 @@ Nothing else changes. The workflow skips its Google Cloud authentication step wh
 Leave `ANTHROPIC_API_KEY` unset, or the API key takes precedence.
 
 > [!IMPORTANT]
-> The token expires roughly a year after it is issued, and nothing warns you beforehand. The review simply starts failing. Re-run `claude setup-token` and replace the secret to rotate it.
+> The token expires roughly a year after creation, and nothing warns you beforehand. The review simply starts failing. Re-run `claude setup-token` and replace the secret to rotate it.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What

Two changes to the Claude PR review workflow. Line-specific findings now post as inline review comments on the lines they concern, instead of collapsing into a single top-level comment. And the review can now authenticate directly to Anthropic, with Vertex AI remaining the default.

## Why

The review previously folded every finding into one conversation comment, which is harder to act on and resolve per finding than the line-anchored threads other review bots leave.

Separately, the review required Vertex AI model access in the dev project, which not every fork of this template can obtain. Setting a repository secret now runs the review with no GCP dependency at all, so a fork can have a working review before, or without, sorting out Vertex access.

## How

- Grant `mcp__github_inline_comment__create_inline_comment` through `claude_args`. `track_progress: true` puts the action in tag mode, whose tool allowlist is otherwise fixed, and the inline-comment MCP server starts only when the allowlist names one of its tools. Without this the server never starts and the tool is unavailable. Multiple `--allowedTools` occurrences accumulate rather than override, so this adds to the tag-mode grants rather than replacing them
- Deliberately do not grant the `mcp__github__*` pending-review family that issue #194 proposed. The inline-comment server exists to provide line comments without full review capabilities, so the reviewer structurally cannot approve or request changes on a pull request. That also drops the dependency on the GitHub MCP tool names, which have churned
- Set `classify_inline_comments: "false"`. At its default the action buffers each inline comment and asks a model to classify it as real feedback or a test probe, dropping the ones judged probes. That classification runs only when an Anthropic API key is present, so leaving it on would make the set of posted comments depend on which auth path a repository uses
- Direct the review prompt to place line-specific findings inline with `suggestion` blocks, and reserve the tracking comment for the summary and cross-cutting notes
- Add `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` as optional repository secrets. Either one skips the Google Cloud authentication step and calls the Anthropic API. `ANTHROPIC_API_KEY` takes precedence when both are set, applied explicitly in the workflow rather than left to credential resolution inside the action
- Add a "Report model auth path" step naming the selected path in the job log, since a failed model call is otherwise indistinguishable across the three paths. It passes booleans through `env` rather than interpolating secret values into the shell script
- Document all three auth paths, the inline-comment mechanism, and troubleshooting in `docs/references/claude-pr-review.md`, with both secrets in `docs/environment-variables.md`

Vertex AI stays the default when neither secret is set, so existing forks are unaffected.

## Tests

- [x] Workflow YAML parses, and both jobs resolve to identical auth wiring, tool grants, and classifier settings
- [x] Pre-commit hooks pass, including `check yaml` on the workflow
- [x] The auth-path report step is shellcheck clean
- [x] All four combinations of the two secrets select the documented path, confirming API key over OAuth token over Vertex AI
- [x] Confirmed in `claude-code-action` source that `allowedTools` is an accumulating flag, so our grant does not displace the tag-mode tools
- [x] Confirmed the inline-comment MCP server registers only when the allowlist names one of its tools, which is why the review previously produced a single comment
- [x] Confirmed the comment classifier runs only when an Anthropic API key is present, and fails open when absent or when its API call fails
- [ ] Live review run. The action requires `claude.yml` to match the default branch during its token exchange, so this pull request skips its own review ([claude-code-action#443](https://github.com/anthropics/claude-code-action/issues/443)). Both changes are first observable on the next pull request opened after this merges

## Related Issues

Closes #194