### PR TITLE
feat(tools): add convert_timestamp tool

### DIFF
--- a/src/agent_foundation/agent.py
+++ b/src/agent_foundation/agent.py
@@ -12,7 +12,7 @@ from .prompt import (
     ROOT_AGENT_INSTRUCTION,
     return_global_instruction,
 )
-from .tools import get_current_time
+from .tools import convert_timestamp, get_current_time
 
 APP_NAME = "agent_foundation"
 ROOT_AGENT_NAME = "agent_foundation"
@@ -27,7 +27,11 @@ root_agent = LlmAgent(
     after_agent_callback=[logging_callbacks.after_agent, add_session_to_memory],
     model=ROOT_AGENT_MODEL,
     instruction=ROOT_AGENT_INSTRUCTION,
-    tools=[FunctionTool(get_current_time), load_memory],
+    tools=[
+        FunctionTool(get_current_time),
+        FunctionTool(convert_timestamp),
+        load_memory,
+    ],
     before_model_callback=logging_callbacks.before_model,
     after_model_callback=logging_callbacks.after_model,
     before_tool_callback=logging_callbacks.before_tool,

--- a/src/agent_foundation/tools.py
+++ b/src/agent_foundation/tools.py
@@ -11,6 +11,7 @@ SUCCESS_STATUS = "success"
 ERROR_STATUS = "error"
 SUCCESS_CODE = "current_time_retrieved"
 INVALID_TIMEZONE_CODE = "invalid_timezone"
+CONVERSION_SUCCESS_CODE = "timestamp_converted"
 
 
 def get_current_time(
@@ -62,4 +63,65 @@ def get_current_time(
         "day_of_week": current_time.strftime("%A"),
         "utc_offset": formatted_utc_offset,
         "utc_time": utc_time.isoformat(timespec="seconds"),
+    }
+
+
+def convert_timestamp(
+    tool_context: ToolContext,
+    timestamp: str,
+    target_timezone_name: str,
+    source_timezone_name: str = DEFAULT_TIMEZONE_NAME,
+) -> dict[str, Any]:
+    """Convert an ISO 8601 timestamp from one timezone to another.
+
+    Args:
+        timestamp: ISO 8601 timestamp such as ``2026-07-25T14:30:00``. A
+            timestamp without an offset is read in the source timezone.
+        target_timezone_name: IANA timezone name to convert into.
+        source_timezone_name: IANA timezone name the timestamp is expressed
+            in when it carries no offset.
+
+    Returns:
+        A dictionary describing either the conversion result or the
+        validation error for an unsupported timezone.
+    """
+    # tool_context: ToolContext injected by ADK for session state access.
+    # Not included in the docstring to avoid confusing the LlmAgent.
+    normalized_target = target_timezone_name.strip() or DEFAULT_TIMEZONE_NAME
+    normalized_source = source_timezone_name.strip() or DEFAULT_TIMEZONE_NAME
+
+    try:
+        target_timezone = ZoneInfo(normalized_target)
+        source_timezone = ZoneInfo(normalized_source)
+    except ZoneInfoNotFoundError:
+        error_message = (
+            f"Unsupported timezone '{normalized_target}' or "
+            f"'{normalized_source}'. Use an IANA timezone name such as "
+            "'UTC' or 'America/New_York'."
+        )
+        return {
+            "status": ERROR_STATUS,
+            "code": INVALID_TIMEZONE_CODE,
+            "message": error_message,
+            "requested_timezone": normalized_target,
+        }
+
+    parsed = datetime.fromisoformat(timestamp)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=source_timezone)
+
+    converted = parsed.astimezone(target_timezone)
+    utc_offset = converted.strftime("%z")
+    formatted_utc_offset = f"{utc_offset[:3]}:{utc_offset[3:]}"
+
+    return {
+        "status": SUCCESS_STATUS,
+        "code": CONVERSION_SUCCESS_CODE,
+        "message": f"Converted timestamp to {normalized_target}.",
+        "timezone_name": normalized_target,
+        "source_timezone_name": normalized_source,
+        "converted_time": converted.isoformat(timespec="seconds"),
+        "day_of_week": converted.strftime("%A"),
+        "utc_offset": formatted_utc_offset,
+        "utc_time": parsed.astimezone(UTC).isoformat(timespec="seconds"),
     }

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -3,11 +3,13 @@
 import re
 
 from agent_foundation.tools import (
+    CONVERSION_SUCCESS_CODE,
     DEFAULT_TIMEZONE_NAME,
     ERROR_STATUS,
     INVALID_TIMEZONE_CODE,
     SUCCESS_CODE,
     SUCCESS_STATUS,
+    convert_timestamp,
     get_current_time,
 )
 
@@ -75,3 +77,67 @@ class TestGetCurrentTime:
             ),
             "requested_timezone": "Mars/Olympus_Mons",
         }
+
+
+class TestConvertTimestamp:
+    """Tests for the convert_timestamp function."""
+
+    def test_convert_timestamp_converts_naive_input_from_source_timezone(
+        self, mock_tool_context
+    ) -> None:
+        """Test that a naive timestamp is read in the source timezone."""
+        result = convert_timestamp(
+            tool_context=mock_tool_context,
+            timestamp="2026-07-25T12:00:00",
+            target_timezone_name="America/New_York",
+        )
+
+        assert result["status"] == SUCCESS_STATUS
+        assert result["code"] == CONVERSION_SUCCESS_CODE
+        assert result["timezone_name"] == "America/New_York"
+        assert result["source_timezone_name"] == DEFAULT_TIMEZONE_NAME
+        assert result["converted_time"] == "2026-07-25T08:00:00-04:00"
+        assert result["day_of_week"] == "Saturday"
+        assert result["utc_offset"] == "-04:00"
+        assert result["utc_time"] == "2026-07-25T12:00:00+00:00"
+
+    def test_convert_timestamp_honors_offset_in_input(self, mock_tool_context) -> None:
+        """Test that an offset-aware timestamp ignores the source timezone."""
+        result = convert_timestamp(
+            tool_context=mock_tool_context,
+            timestamp="2026-07-25T12:00:00+02:00",
+            target_timezone_name="UTC",
+            source_timezone_name="America/New_York",
+        )
+
+        assert result["converted_time"] == "2026-07-25T10:00:00+00:00"
+        assert result["message"] == "Converted timestamp to UTC."
+
+    def test_convert_timestamp_uses_default_timezones_for_blank_input(
+        self, mock_tool_context
+    ) -> None:
+        """Test that blank timezone input falls back to UTC."""
+        result = convert_timestamp(
+            tool_context=mock_tool_context,
+            timestamp="2026-07-25T12:00:00",
+            target_timezone_name="  ",
+            source_timezone_name="",
+        )
+
+        assert result["timezone_name"] == DEFAULT_TIMEZONE_NAME
+        assert result["source_timezone_name"] == DEFAULT_TIMEZONE_NAME
+        assert result["utc_offset"] == "+00:00"
+
+    def test_convert_timestamp_returns_error_for_invalid_timezone(
+        self, mock_tool_context_empty_state
+    ) -> None:
+        """Test that an unsupported timezone returns a clear error response."""
+        result = convert_timestamp(
+            tool_context=mock_tool_context_empty_state,
+            timestamp="2026-07-25T12:00:00",
+            target_timezone_name="Mars/Olympus_Mons",
+        )
+
+        assert result["status"] == ERROR_STATUS
+        assert result["code"] == INVALID_TIMEZONE_CODE
+        assert result["requested_timezone"] == "Mars/Olympus_Mons"


### PR DESCRIPTION
## What

Adds a `convert_timestamp` tool that converts an ISO 8601 timestamp between IANA timezones, and registers it on `root_agent`.

## Why

Test PR for the Claude PR review workflow. The change is small and self-contained so the review has concrete, line-anchored material to comment on.

## How

- Add `convert_timestamp` to `tools.py` (target and source timezone, naive input read in the source timezone)
- Register it on `root_agent` alongside `get_current_time`
- Add unit tests covering conversion, offset-aware input, blank timezone fallback, and unsupported timezone

## Tests

- [x] `uv run ruff format && uv run ruff check --fix && uv run mypy && uv run pytest --cov` (89 passed, 100% coverage)

## Notes

Not intended to merge. Open to exercise the review workflow, then close.